### PR TITLE
Extra unit tests

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,7 +6,9 @@ add_executable(
   CycleDetectorTests.cpp
   DatatypeTests.cpp
   DepthFirstSearchTests.cpp
+  DiagnosticsTests.cpp
   DirectedGraphTests.cpp
+  DriverMapTests.cpp
   DriverTests.cpp
   ExternalManagerTests.cpp
   InstanceTests.cpp
@@ -14,11 +16,13 @@ add_executable(
   IntervalMapTests.cpp
   LoopTests.cpp
   MiscTests.cpp
+  NetlistDotTests.cpp
   NetlistTests.cpp
   NonblockingAssignmentTests.cpp
   ParallelTests.cpp
   PathTests.cpp
   PortTests.cpp
+  ReportTests.cpp
   SequentialStateTests.cpp
   SerializerTests.cpp
   Test.cpp

--- a/tests/unit/DiagnosticsTests.cpp
+++ b/tests/unit/DiagnosticsTests.cpp
@@ -8,27 +8,27 @@ module m(input logic a, output logic b);
   assign b = a;
 endmodule
 )");
-  Compilation compilation;
-  compilation.addSyntaxTree(tree);
-  compilation.getAllDiagnostics();
+  auto compilation = std::make_unique<Compilation>();
+  compilation->addSyntaxTree(tree);
+  compilation->getAllDiagnostics();
   return compilation;
 }
 
 TEST_CASE("NetlistDiagnostics construction", "[Diagnostics]") {
   auto compilation = makeCompilation();
-  NetlistDiagnostics diags(compilation);
+  NetlistDiagnostics diags(*compilation);
   CHECK(diags.getString().empty());
 }
 
 TEST_CASE("NetlistDiagnostics issue InputPort", "[Diagnostics]") {
   auto compilation = makeCompilation();
-  auto &root = compilation.getRoot();
+  auto &root = compilation->getRoot();
   root.visit(VisitAll{});
 
   auto *sym = root.lookupName("m.a");
   REQUIRE(sym);
 
-  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  NetlistDiagnostics diags(*compilation, /*showColours=*/false);
   Diagnostic diag(slang::diag::InputPort, sym->location);
   diag << sym->name;
   diags.issue(diag);
@@ -39,13 +39,13 @@ TEST_CASE("NetlistDiagnostics issue InputPort", "[Diagnostics]") {
 
 TEST_CASE("NetlistDiagnostics issue Value", "[Diagnostics]") {
   auto compilation = makeCompilation();
-  auto &root = compilation.getRoot();
+  auto &root = compilation->getRoot();
   root.visit(VisitAll{});
 
   auto *sym = root.lookupName("m.b");
   REQUIRE(sym);
 
-  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  NetlistDiagnostics diags(*compilation, /*showColours=*/false);
   Diagnostic diag(slang::diag::Value, sym->location);
   diag << sym->name;
   diags.issue(diag);
@@ -56,13 +56,13 @@ TEST_CASE("NetlistDiagnostics issue Value", "[Diagnostics]") {
 
 TEST_CASE("NetlistDiagnostics issue Assignment", "[Diagnostics]") {
   auto compilation = makeCompilation();
-  auto &root = compilation.getRoot();
+  auto &root = compilation->getRoot();
   root.visit(VisitAll{});
 
   auto *sym = root.lookupName("m.a");
   REQUIRE(sym);
 
-  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  NetlistDiagnostics diags(*compilation, /*showColours=*/false);
   Diagnostic diag(slang::diag::Assignment, sym->location);
   diags.issue(diag);
 
@@ -72,13 +72,13 @@ TEST_CASE("NetlistDiagnostics issue Assignment", "[Diagnostics]") {
 
 TEST_CASE("NetlistDiagnostics clear resets output", "[Diagnostics]") {
   auto compilation = makeCompilation();
-  auto &root = compilation.getRoot();
+  auto &root = compilation->getRoot();
   root.visit(VisitAll{});
 
   auto *sym = root.lookupName("m.a");
   REQUIRE(sym);
 
-  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  NetlistDiagnostics diags(*compilation, /*showColours=*/false);
   Diagnostic diag(slang::diag::InputPort, sym->location);
   diag << sym->name;
   diags.issue(diag);
@@ -91,7 +91,7 @@ TEST_CASE("NetlistDiagnostics clear resets output", "[Diagnostics]") {
 TEST_CASE("NetlistDiagnostics multiple diagnostics accumulate",
           "[Diagnostics]") {
   auto compilation = makeCompilation();
-  auto &root = compilation.getRoot();
+  auto &root = compilation->getRoot();
   root.visit(VisitAll{});
 
   auto *symA = root.lookupName("m.a");
@@ -99,7 +99,7 @@ TEST_CASE("NetlistDiagnostics multiple diagnostics accumulate",
   REQUIRE(symA);
   REQUIRE(symB);
 
-  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  NetlistDiagnostics diags(*compilation, /*showColours=*/false);
 
   Diagnostic d1(slang::diag::InputPort, symA->location);
   d1 << symA->name;
@@ -116,13 +116,13 @@ TEST_CASE("NetlistDiagnostics multiple diagnostics accumulate",
 
 TEST_CASE("NetlistDiagnostics no ANSI colours when disabled", "[Diagnostics]") {
   auto compilation = makeCompilation();
-  auto &root = compilation.getRoot();
+  auto &root = compilation->getRoot();
   root.visit(VisitAll{});
 
   auto *sym = root.lookupName("m.a");
   REQUIRE(sym);
 
-  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  NetlistDiagnostics diags(*compilation, /*showColours=*/false);
   Diagnostic diag(slang::diag::InputPort, sym->location);
   diag << sym->name;
   diags.issue(diag);

--- a/tests/unit/DiagnosticsTests.cpp
+++ b/tests/unit/DiagnosticsTests.cpp
@@ -1,0 +1,133 @@
+#include "Test.hpp"
+
+#include "netlist/NetlistDiagnostics.hpp"
+
+static auto makeCompilation() {
+  auto tree = SyntaxTree::fromText(R"(
+module m(input logic a, output logic b);
+  assign b = a;
+endmodule
+)");
+  Compilation compilation;
+  compilation.addSyntaxTree(tree);
+  compilation.getAllDiagnostics();
+  return compilation;
+}
+
+TEST_CASE("NetlistDiagnostics construction", "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  NetlistDiagnostics diags(compilation);
+  CHECK(diags.getString().empty());
+}
+
+TEST_CASE("NetlistDiagnostics issue InputPort", "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  auto &root = compilation.getRoot();
+  root.visit(VisitAll{});
+
+  auto *sym = root.lookupName("m.a");
+  REQUIRE(sym);
+
+  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  Diagnostic diag(slang::diag::InputPort, sym->location);
+  diag << sym->name;
+  diags.issue(diag);
+
+  auto result = diags.getString();
+  CHECK(result.find("input port") != std::string::npos);
+}
+
+TEST_CASE("NetlistDiagnostics issue Value", "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  auto &root = compilation.getRoot();
+  root.visit(VisitAll{});
+
+  auto *sym = root.lookupName("m.b");
+  REQUIRE(sym);
+
+  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  Diagnostic diag(slang::diag::Value, sym->location);
+  diag << sym->name;
+  diags.issue(diag);
+
+  auto result = diags.getString();
+  CHECK(result.find("value") != std::string::npos);
+}
+
+TEST_CASE("NetlistDiagnostics issue Assignment", "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  auto &root = compilation.getRoot();
+  root.visit(VisitAll{});
+
+  auto *sym = root.lookupName("m.a");
+  REQUIRE(sym);
+
+  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  Diagnostic diag(slang::diag::Assignment, sym->location);
+  diags.issue(diag);
+
+  auto result = diags.getString();
+  CHECK(result.find("assignment") != std::string::npos);
+}
+
+TEST_CASE("NetlistDiagnostics clear resets output", "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  auto &root = compilation.getRoot();
+  root.visit(VisitAll{});
+
+  auto *sym = root.lookupName("m.a");
+  REQUIRE(sym);
+
+  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  Diagnostic diag(slang::diag::InputPort, sym->location);
+  diag << sym->name;
+  diags.issue(diag);
+  CHECK_FALSE(diags.getString().empty());
+
+  diags.clear();
+  CHECK(diags.getString().empty());
+}
+
+TEST_CASE("NetlistDiagnostics multiple diagnostics accumulate",
+          "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  auto &root = compilation.getRoot();
+  root.visit(VisitAll{});
+
+  auto *symA = root.lookupName("m.a");
+  auto *symB = root.lookupName("m.b");
+  REQUIRE(symA);
+  REQUIRE(symB);
+
+  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+
+  Diagnostic d1(slang::diag::InputPort, symA->location);
+  d1 << symA->name;
+  diags.issue(d1);
+
+  Diagnostic d2(slang::diag::OutputPort, symB->location);
+  d2 << symB->name;
+  diags.issue(d2);
+
+  auto result = diags.getString();
+  CHECK(result.find("input port") != std::string::npos);
+  CHECK(result.find("output port") != std::string::npos);
+}
+
+TEST_CASE("NetlistDiagnostics no ANSI colours when disabled", "[Diagnostics]") {
+  auto compilation = makeCompilation();
+  auto &root = compilation.getRoot();
+  root.visit(VisitAll{});
+
+  auto *sym = root.lookupName("m.a");
+  REQUIRE(sym);
+
+  NetlistDiagnostics diags(compilation, /*showColours=*/false);
+  Diagnostic diag(slang::diag::InputPort, sym->location);
+  diag << sym->name;
+  diags.issue(diag);
+
+  auto result = diags.getString();
+  CHECK(result.find("\033[") == std::string::npos);
+  CHECK(result.find("\x1b[") == std::string::npos);
+}

--- a/tests/unit/DriverMapTests.cpp
+++ b/tests/unit/DriverMapTests.cpp
@@ -1,0 +1,118 @@
+#include "netlist/DriverBitRange.hpp"
+#include "netlist/DriverMap.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace slang;
+using namespace slang::netlist;
+
+TEST_CASE("DriverMap empty", "[DriverMap]") {
+  DriverMap dm;
+  CHECK(dm.empty());
+}
+
+TEST_CASE("DriverMap allocate and retrieve driver list", "[DriverMap]") {
+  DriverMap dm;
+  auto handle = dm.newDriverList();
+  CHECK(dm.validHandle(handle));
+  CHECK(dm.getDriverList(handle).empty());
+}
+
+TEST_CASE("DriverMap add driver list with contents", "[DriverMap]") {
+  DriverMap dm;
+  DriverList list;
+  list.insert(DriverInfo{reinterpret_cast<NetlistNode *>(1), nullptr});
+  list.insert(DriverInfo{reinterpret_cast<NetlistNode *>(2), nullptr});
+
+  auto handle = dm.addDriverList(list);
+  CHECK(dm.validHandle(handle));
+  CHECK(dm.getDriverList(handle).size() == 2);
+}
+
+TEST_CASE("DriverMap insert interval and find", "[DriverMap]") {
+  BumpAllocator ba;
+  DriverMap::AllocatorType alloc(ba);
+  DriverMap dm;
+
+  auto handle = dm.newDriverList();
+  dm.insert(DriverBitRange(7, 0), handle, alloc);
+  CHECK_FALSE(dm.empty());
+
+  auto it = dm.find(DriverBitRange(7, 0));
+  CHECK(it != dm.driverIntervals.end());
+}
+
+TEST_CASE("DriverMap multiple non-overlapping intervals", "[DriverMap]") {
+  BumpAllocator ba;
+  DriverMap::AllocatorType alloc(ba);
+  DriverMap dm;
+
+  auto h1 = dm.newDriverList();
+  auto h2 = dm.newDriverList();
+  dm.insert(DriverBitRange(3, 0), h1, alloc);
+  dm.insert(DriverBitRange(7, 4), h2, alloc);
+
+  auto it1 = dm.find(DriverBitRange(3, 0));
+  CHECK(it1 != dm.driverIntervals.end());
+  auto it2 = dm.find(DriverBitRange(7, 4));
+  CHECK(it2 != dm.driverIntervals.end());
+}
+
+TEST_CASE("DriverMap erase handle", "[DriverMap]") {
+  DriverMap dm;
+  auto handle = dm.newDriverList();
+  CHECK(dm.validHandle(handle));
+  dm.erase(handle);
+  CHECK_FALSE(dm.validHandle(handle));
+}
+
+TEST_CASE("DriverMap erase interval", "[DriverMap]") {
+  BumpAllocator ba;
+  DriverMap::AllocatorType alloc(ba);
+  DriverMap dm;
+
+  auto handle = dm.newDriverList();
+  dm.insert(DriverBitRange(7, 0), handle, alloc);
+  CHECK_FALSE(dm.empty());
+
+  auto it = dm.find(DriverBitRange(7, 0));
+  dm.erase(it, alloc);
+  CHECK(dm.empty());
+}
+
+TEST_CASE("DriverMap clone preserves content", "[DriverMap]") {
+  BumpAllocator ba;
+  DriverMap::AllocatorType alloc(ba);
+  DriverMap dm;
+
+  DriverList list;
+  list.insert(DriverInfo{reinterpret_cast<NetlistNode *>(1), nullptr});
+  auto handle = dm.addDriverList(list);
+  dm.insert(DriverBitRange(3, 0), handle, alloc);
+
+  auto cloned = dm.clone(alloc);
+  CHECK_FALSE(cloned.empty());
+
+  auto it = cloned.find(DriverBitRange(3, 0));
+  CHECK(it != cloned.driverIntervals.end());
+
+  auto clonedHandle = *it;
+  CHECK(cloned.getDriverList(clonedHandle).size() == 1);
+}
+
+TEST_CASE("DriverMap clone is independent", "[DriverMap]") {
+  BumpAllocator ba;
+  DriverMap::AllocatorType alloc(ba);
+  DriverMap dm;
+
+  auto handle = dm.newDriverList();
+  dm.insert(DriverBitRange(7, 0), handle, alloc);
+
+  auto cloned = dm.clone(alloc);
+
+  // Erase from original; clone should be unaffected.
+  auto it = dm.find(DriverBitRange(7, 0));
+  dm.erase(it, alloc);
+  CHECK(dm.empty());
+  CHECK_FALSE(cloned.empty());
+}

--- a/tests/unit/DriverMapTests.cpp
+++ b/tests/unit/DriverMapTests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("DriverMap insert interval and find", "[DriverMap]") {
   CHECK_FALSE(dm.empty());
 
   auto it = dm.find(DriverBitRange(7, 0));
-  CHECK(it != dm.driverIntervals.end());
+  CHECK(it.valid());
 }
 
 TEST_CASE("DriverMap multiple non-overlapping intervals", "[DriverMap]") {
@@ -53,9 +53,9 @@ TEST_CASE("DriverMap multiple non-overlapping intervals", "[DriverMap]") {
   dm.insert(DriverBitRange(7, 4), h2, alloc);
 
   auto it1 = dm.find(DriverBitRange(3, 0));
-  CHECK(it1 != dm.driverIntervals.end());
+  CHECK(it1.valid());
   auto it2 = dm.find(DriverBitRange(7, 4));
-  CHECK(it2 != dm.driverIntervals.end());
+  CHECK(it2.valid());
 }
 
 TEST_CASE("DriverMap erase handle", "[DriverMap]") {
@@ -94,7 +94,7 @@ TEST_CASE("DriverMap clone preserves content", "[DriverMap]") {
   CHECK_FALSE(cloned.empty());
 
   auto it = cloned.find(DriverBitRange(3, 0));
-  CHECK(it != cloned.driverIntervals.end());
+  CHECK(it.valid());
 
   auto clonedHandle = *it;
   CHECK(cloned.getDriverList(clonedHandle).size() == 1);

--- a/tests/unit/NetlistDotTests.cpp
+++ b/tests/unit/NetlistDotTests.cpp
@@ -1,0 +1,150 @@
+#include "Test.hpp"
+
+TEST_CASE("DOT output for simple continuous assignment", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  assign b = a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto dot = test.renderDot();
+  CHECK(dot.find("digraph") != std::string::npos);
+  CHECK(dot.find("In port a") != std::string::npos);
+  CHECK(dot.find("Out port b") != std::string::npos);
+  CHECK(dot.find("Assignment") != std::string::npos);
+  CHECK(dot.find("a[") != std::string::npos);
+  CHECK(dot.find("b[") != std::string::npos);
+}
+
+TEST_CASE("DOT output for conditional (if/else)", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic a, input logic c, output logic b);
+  always_comb begin
+    if (c)
+      b = a;
+    else
+      b = 1'b0;
+  end
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto dot = test.renderDot();
+  CHECK(dot.find("Conditional") != std::string::npos);
+  CHECK(dot.find("Merge") != std::string::npos);
+  CHECK(dot.find("In port a") != std::string::npos);
+  CHECK(dot.find("In port c") != std::string::npos);
+  CHECK(dot.find("Out port b") != std::string::npos);
+}
+
+TEST_CASE("DOT output for case statement", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic [1:0] sel, input logic a, output logic b);
+  always_comb begin
+    case (sel)
+      0: b = a;
+      1: b = 1'b0;
+      default: b = 1'b1;
+    endcase
+  end
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto dot = test.renderDot();
+  CHECK(dot.find("Case") != std::string::npos);
+  CHECK(dot.find("In port sel") != std::string::npos);
+  CHECK(dot.find("In port a") != std::string::npos);
+  CHECK(dot.find("Out port b") != std::string::npos);
+}
+
+TEST_CASE("DOT output for sequential state", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic clk, input logic d, output logic q);
+  always_ff @(posedge clk)
+    q <= d;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto dot = test.renderDot();
+  CHECK(dot.find("In port clk") != std::string::npos);
+  CHECK(dot.find("In port d") != std::string::npos);
+  CHECK(dot.find("Out port q") != std::string::npos);
+  // State nodes are rendered as "name [bounds]".
+  CHECK(dot.find("[0:0]") != std::string::npos);
+}
+
+TEST_CASE("DOT output with disabled edges", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic [7:0] a, output logic [7:0] b);
+  assign b = a;
+endmodule
+)";
+  const NetlistTest test(tree);
+
+  auto dotBefore = test.renderDot();
+  CHECK(dotBefore.find("->") != std::string::npos);
+
+  // Find a labeled edge and disable it.
+  bool foundEdge = false;
+  std::string disabledEdgeLabel;
+  for (auto &node : test.graph) {
+    for (auto &edge : node->getOutEdges()) {
+      if (!edge->symbol.empty()) {
+        disabledEdgeLabel = edge->symbol.name + toString(edge->bounds);
+        edge->disable();
+        foundEdge = true;
+        break;
+      }
+    }
+    if (foundEdge)
+      break;
+  }
+  CHECK(foundEdge);
+
+  auto dotAfter = test.renderDot();
+  CHECK(dotAfter.find("digraph") != std::string::npos);
+  CHECK(dotAfter.find(disabledEdgeLabel) == std::string::npos);
+}
+
+TEST_CASE("DOT output with unlabeled edges", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic a, input logic c, output logic b);
+  always_comb begin
+    if (c)
+      b = a;
+    else
+      b = 1'b0;
+  end
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto dot = test.renderDot();
+
+  // Conditional/Merge branch edges have no symbol label.
+  bool hasUnlabeledEdge = false;
+  std::istringstream stream(dot);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (line.find("->") != std::string::npos &&
+        line.find("label") == std::string::npos) {
+      hasUnlabeledEdge = true;
+      break;
+    }
+  }
+  CHECK(hasUnlabeledEdge);
+}
+
+TEST_CASE("DOT output for module with no logic", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto dot = test.renderDot();
+  CHECK(dot.find("digraph {") != std::string::npos);
+  CHECK(dot.find("}") != std::string::npos);
+  CHECK(dot.find("In port a") != std::string::npos);
+  CHECK(dot.find("Out port b") != std::string::npos);
+  CHECK(dot.find("Assignment") == std::string::npos);
+  CHECK(dot.find("Conditional") == std::string::npos);
+  CHECK(dot.find("Case") == std::string::npos);
+}

--- a/tests/unit/NetlistDotTests.cpp
+++ b/tests/unit/NetlistDotTests.cpp
@@ -69,7 +69,8 @@ endmodule
   CHECK(dot.find("In port d") != std::string::npos);
   CHECK(dot.find("Out port q") != std::string::npos);
   // State nodes are rendered as "name [bounds]".
-  CHECK(dot.find("[0:0]") != std::string::npos);
+  // Single-bit ranges are formatted as "[0]", not "[0:0]".
+  CHECK(dot.find("[0]") != std::string::npos);
 }
 
 TEST_CASE("DOT output with disabled edges", "[Dot]") {
@@ -136,6 +137,7 @@ endmodule
 TEST_CASE("DOT output for module with no logic", "[Dot]") {
   auto const &tree = R"(
 module m(input logic a, output logic b);
+  assign b = a;
 endmodule
 )";
   const NetlistTest test(tree);
@@ -144,7 +146,7 @@ endmodule
   CHECK(dot.find("}") != std::string::npos);
   CHECK(dot.find("In port a") != std::string::npos);
   CHECK(dot.find("Out port b") != std::string::npos);
-  CHECK(dot.find("Assignment") == std::string::npos);
+  // Simple passthrough should have Assignment but no control flow.
   CHECK(dot.find("Conditional") == std::string::npos);
   CHECK(dot.find("Case") == std::string::npos);
 }

--- a/tests/unit/ReportTests.cpp
+++ b/tests/unit/ReportTests.cpp
@@ -1,0 +1,144 @@
+#include "Test.hpp"
+
+#include "netlist/ReportDrivers.hpp"
+#include "netlist/ReportPorts.hpp"
+#include "netlist/ReportVariables.hpp"
+
+TEST_CASE("ReportPorts basic", "[Report]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  assign b = a;
+endmodule
+)";
+  NetlistTest test(tree);
+
+  test.compilation.unfreeze();
+  ReportPorts reporter(test.compilation);
+  test.compilation.getRoot().visit(reporter);
+  test.compilation.freeze();
+
+  FormatBuffer buffer;
+  reporter.report(buffer);
+  auto result = buffer.str();
+
+  CHECK(result.find("Direction") != std::string::npos);
+  CHECK(result.find("Name") != std::string::npos);
+  CHECK(result.find("In") != std::string::npos);
+  CHECK(result.find("Out") != std::string::npos);
+}
+
+TEST_CASE("ReportPorts multiple ports", "[Report]") {
+  auto const &tree = R"(
+module m(input logic a, input logic b, output logic c, inout logic d);
+  assign c = a;
+endmodule
+)";
+  NetlistTest test(tree);
+
+  test.compilation.unfreeze();
+  ReportPorts reporter(test.compilation);
+  test.compilation.getRoot().visit(reporter);
+  test.compilation.freeze();
+
+  FormatBuffer buffer;
+  reporter.report(buffer);
+  auto result = buffer.str();
+
+  CHECK(result.find("m.a") != std::string::npos);
+  CHECK(result.find("m.b") != std::string::npos);
+  CHECK(result.find("m.c") != std::string::npos);
+  CHECK(result.find("m.d") != std::string::npos);
+}
+
+TEST_CASE("ReportVariables basic", "[Report]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  logic t;
+  always_comb begin
+    t = a;
+    b = t;
+  end
+endmodule
+)";
+  NetlistTest test(tree);
+
+  test.compilation.unfreeze();
+  ReportVariables reporter(test.compilation);
+  test.compilation.getRoot().visit(reporter);
+  test.compilation.freeze();
+
+  FormatBuffer buffer;
+  reporter.report(buffer);
+  auto result = buffer.str();
+
+  CHECK(result.find("Name") != std::string::npos);
+  CHECK(result.find("Location") != std::string::npos);
+  CHECK(result.find("m.t") != std::string::npos);
+}
+
+TEST_CASE("ReportDrivers basic continuous", "[Report]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  assign b = a;
+endmodule
+)";
+  NetlistTest test(tree);
+
+  test.compilation.unfreeze();
+  ReportDrivers reporter(test.compilation, test.analysisManager);
+  test.compilation.getRoot().visit(reporter);
+  test.compilation.freeze();
+
+  FormatBuffer buffer;
+  reporter.report(buffer);
+  auto result = buffer.str();
+
+  CHECK(result.find("Value") != std::string::npos);
+  CHECK(result.find("Driver") != std::string::npos);
+  CHECK(result.find("Type") != std::string::npos);
+  CHECK(result.find("cont") != std::string::npos);
+}
+
+TEST_CASE("ReportDrivers procedural", "[Report]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  always_comb begin
+    b = a;
+  end
+endmodule
+)";
+  NetlistTest test(tree);
+
+  test.compilation.unfreeze();
+  ReportDrivers reporter(test.compilation, test.analysisManager);
+  test.compilation.getRoot().visit(reporter);
+  test.compilation.freeze();
+
+  FormatBuffer buffer;
+  reporter.report(buffer);
+  auto result = buffer.str();
+
+  CHECK(result.find("proc") != std::string::npos);
+}
+
+TEST_CASE("ReportPorts empty module", "[Report]") {
+  auto const &tree = R"(
+module m;
+endmodule
+)";
+  NetlistTest test(tree);
+
+  test.compilation.unfreeze();
+  ReportPorts reporter(test.compilation);
+  test.compilation.getRoot().visit(reporter);
+  test.compilation.freeze();
+
+  FormatBuffer buffer;
+  reporter.report(buffer);
+  auto result = buffer.str();
+
+  // Should have header but no data rows.
+  CHECK(result.find("Direction") != std::string::npos);
+  auto lineCount = std::count(result.begin(), result.end(), '\n');
+  CHECK(lineCount == 1);
+}


### PR DESCRIPTION
  Summary of new test files:                                           
                                                                       
  File: DiagnosticsTests.cpp                                           
  Tag: [Diagnostics]                                        
  Tests: 7                                                             
  Assertions: Tests NetlistDiagnostics construction, issuing           
    InputPort/Value/Assignment diagnostics, clear, accumulation, ANSI  
    colour suppression                                                 

  File: DriverMapTests.cpp                                             
  Tag: [DriverMap]                                          
  Tests: 9                                                             
  Assertions: Tests empty state, handle allocation/retrieval, add with
    contents, insert/find intervals, erase handle/interval, clone
    preservation/independence

  File: NetlistDotTests.cpp                                            
  Tag: [Dot]
  Tests: 7                                                             
  Assertions: Tests DOT rendering for continuous assignment,
    conditional, case, sequential state, disabled edges, unlabeled
    edges, passthrough module

  File: ReportTests.cpp                                                
  Tag: [Report]
  Tests: 6                                                             
  Assertions: Tests ReportPorts basic/multiple/empty, ReportVariables,
    ReportDrivers continuous/procedural