### PR TITLE
Add lookup of netlist nodes by name and bit range

### DIFF
--- a/bindings/python/pyslang_netlist.cpp
+++ b/bindings/python/pyslang_netlist.cpp
@@ -51,6 +51,20 @@ PYBIND11_MODULE(pyslang_netlist, m) {
             return node ? py::cast(node) : py::none();
           },
           py::arg("name"), "Lookup a node by hierarchical name.")
+      .def(
+          "lookup_by_range",
+          [](const netlist::NetlistGraph &self, std::string_view name,
+             int32_t lower, int32_t upper) {
+            auto nodes =
+                self.lookup(name, netlist::DriverBitRange(lower, upper));
+            py::list result;
+            for (auto *node : nodes) {
+              result.append(py::cast(node, py::return_value_policy::reference));
+            }
+            return result;
+          },
+          py::arg("name"), py::arg("lower"), py::arg("upper"),
+          "Lookup nodes by hierarchical name and bit range overlap.")
       .def("num_nodes", &netlist::NetlistGraph::numNodes,
            "Get the number of nodes in the graph.")
       .def("num_edges", &netlist::NetlistGraph::numEdges,

--- a/include/netlist/NetlistGraph.hpp
+++ b/include/netlist/NetlistGraph.hpp
@@ -8,6 +8,9 @@
 
 #include <algorithm>
 #include <ranges>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace slang::netlist {
 
@@ -21,6 +24,13 @@ public:
   /// @param name The hierarchical name of the node.
   /// @return A pointer to the node if found, or nullptr if not found.
   [[nodiscard]] auto lookup(std::string_view name) const -> NetlistNode *;
+
+  /// Lookup nodes by hierarchical name and bit range.
+  ///
+  /// Returns all Port, Variable, and State nodes whose hierarchical path
+  /// matches @p name and whose bounds overlap with @p bounds.
+  [[nodiscard]] auto lookup(std::string_view name, DriverBitRange bounds) const
+      -> std::vector<NetlistNode *>;
 
   /// Return a view of all nodes of the specified kind.
   ///
@@ -39,6 +49,11 @@ public:
       -> NetlistEdge & {
     return sourceNode.addEdge(targetNode);
   }
+
+private:
+  mutable bool indexBuilt = false;
+  mutable std::unordered_map<std::string, std::vector<NetlistNode *>> nodeIndex;
+  void buildIndex() const;
 };
 
 } // namespace slang::netlist

--- a/include/netlist/NetlistNode.hpp
+++ b/include/netlist/NetlistNode.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "netlist/DirectedGraph.hpp"
@@ -48,6 +50,12 @@ public:
     SLANG_ASSERT(T::isKind(kind));
     return const_cast<T &>(*(static_cast<const T *>(this)));
   }
+
+  /// Get the hierarchical path of this node, if it has one.
+  auto getHierarchicalPath() const -> std::optional<std::string_view>;
+
+  /// Get the bit range bounds of this node, if it has them.
+  auto getBounds() const -> std::optional<DriverBitRange>;
 
 private:
   static std::atomic<size_t> nextID;
@@ -155,5 +163,32 @@ public:
     return otherKind == NodeKind::Merge;
   }
 };
+
+inline auto NetlistNode::getHierarchicalPath() const
+    -> std::optional<std::string_view> {
+  switch (kind) {
+  case NodeKind::Port:
+    return as<Port>().hierarchicalPath;
+  case NodeKind::Variable:
+    return as<Variable>().hierarchicalPath;
+  case NodeKind::State:
+    return as<State>().hierarchicalPath;
+  default:
+    return std::nullopt;
+  }
+}
+
+inline auto NetlistNode::getBounds() const -> std::optional<DriverBitRange> {
+  switch (kind) {
+  case NodeKind::Port:
+    return as<Port>().bounds;
+  case NodeKind::Variable:
+    return as<Variable>().bounds;
+  case NodeKind::State:
+    return as<State>().bounds;
+  default:
+    return std::nullopt;
+  }
+}
 
 } // namespace slang::netlist

--- a/source/NetlistBuilder.cpp
+++ b/source/NetlistBuilder.cpp
@@ -15,19 +15,6 @@ namespace slang::netlist {
 
 namespace {
 
-/// Get the driver bit range for a given node, if it has one.
-auto getNodeBounds(NetlistNode const &node) -> std::optional<DriverBitRange> {
-  switch (node.kind) {
-  case NodeKind::Port:
-    return node.as<Port>().bounds;
-  case NodeKind::Variable:
-    return node.as<Variable>().bounds;
-  case NodeKind::State:
-    return node.as<State>().bounds;
-  default:
-    return std::nullopt;
-  }
-}
 /// Thread-local pointer to the deferred work buffer for the current parallel
 /// task. nullptr when running sequentially.
 thread_local DeferredGraphWork *threadLocalDeferredWork = nullptr;
@@ -191,7 +178,7 @@ void NetlistBuilder::addDependency(NetlistNode &source, NetlistNode &target,
                                    ast::EdgeKind edgeKind) {
 
   // Retrieve the bounds of the driving node, if any.
-  auto nodeBounds = getNodeBounds(source);
+  auto nodeBounds = source.getBounds();
 
   // By default, use the specified bounds for the edge.
   auto edgeBounds = bounds;
@@ -553,7 +540,7 @@ void NetlistBuilder::mergeDrivers(ast::EvalContext &evalCtx,
           // bounds. Eg when interface members are assigned to directly.
           if (auto *varNode =
                   getVariable(symbol->as<ast::VariableSymbol>(), it.bounds())) {
-            auto varBounds = getNodeBounds(*varNode);
+            auto varBounds = varNode->getBounds();
             SLANG_ASSERT(varBounds.has_value());
             addDependency(*driver.node, *varNode, symRef, *varBounds);
           }

--- a/source/NetlistGraph.cpp
+++ b/source/NetlistGraph.cpp
@@ -2,23 +2,43 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <string_view>
 
 using namespace slang::netlist;
 
-auto NetlistGraph::lookup(std::string_view name) const -> NetlistNode * {
-  auto compare = [&](const std::unique_ptr<NetlistNode> &node) -> bool {
-    switch (node->kind) {
-    case NodeKind::Port:
-      return node->as<Port>().hierarchicalPath == name;
-    case NodeKind::Variable:
-      return node->as<Variable>().hierarchicalPath == name;
-    case NodeKind::State:
-      return node->as<State>().hierarchicalPath == name;
-    default:
-      return false;
+void NetlistGraph::buildIndex() const {
+  if (indexBuilt)
+    return;
+  for (auto const &node : nodes) {
+    auto path = node->getHierarchicalPath();
+    if (path.has_value()) {
+      nodeIndex[std::string(*path)].push_back(node.get());
     }
-  };
-  auto it = std::ranges::find_if(*this, compare);
-  return it != this->end() ? it->get() : nullptr;
+  }
+  indexBuilt = true;
+}
+
+auto NetlistGraph::lookup(std::string_view name) const -> NetlistNode * {
+  buildIndex();
+  auto it = nodeIndex.find(std::string(name));
+  if (it == nodeIndex.end() || it->second.empty())
+    return nullptr;
+  return it->second.front();
+}
+
+auto NetlistGraph::lookup(std::string_view name, DriverBitRange bounds) const
+    -> std::vector<NetlistNode *> {
+  buildIndex();
+  std::vector<NetlistNode *> result;
+  auto it = nodeIndex.find(std::string(name));
+  if (it == nodeIndex.end())
+    return result;
+  for (auto *node : it->second) {
+    auto nodeBounds = node->getBounds();
+    if (nodeBounds.has_value() && nodeBounds->overlaps(bounds)) {
+      result.push_back(node);
+    }
+  }
+  return result;
 }

--- a/tests/bindings/python/test_netlistgraph.py
+++ b/tests/bindings/python/test_netlistgraph.py
@@ -91,6 +91,24 @@ class TestNetlistGraph(unittest.TestCase):
         # A combinatorial path exists from a to c.
         self.assertFalse(finder.find_comb(start, comb_end).empty())
 
+    def test_lookup_by_range(self):
+        code = """
+        module m(input logic [7:0] a, output logic [7:0] b);
+            assign b = a;
+        endmodule
+        """
+        test = NetlistGraphTest(code)
+        # Port 'a' has bounds [0,7]. Query [3,5] overlaps.
+        results = test.graph.lookup_by_range("m.a", 3, 5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].kind, pyslang_netlist.NodeKind.Port)
+        # Non-overlapping range returns empty.
+        results = test.graph.lookup_by_range("m.a", 8, 15)
+        self.assertEqual(len(results), 0)
+        # Non-existent name returns empty.
+        results = test.graph.lookup_by_range("m.nonexistent", 0, 0)
+        self.assertEqual(len(results), 0)
+
     def test_iter_nodes(self):
         code = "module m(output logic a); assign a = 1; endmodule"
         test = NetlistGraphTest(code)

--- a/tests/unit/NetlistTests.cpp
+++ b/tests/unit/NetlistTests.cpp
@@ -124,3 +124,80 @@ endmodule
   CHECK(test.graph.lookup("m.nonexistent") == nullptr);
   CHECK(test.graph.lookup("") == nullptr);
 }
+
+TEST_CASE("NetlistGraph::lookup by name and range, exact match", "[Netlist]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  assign b = a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  // Port 'a' has bounds [0,0].
+  auto results = test.graph.lookup("m.a", netlist::DriverBitRange(0, 0));
+  CHECK(results.size() == 1);
+  CHECK(results[0]->kind == NodeKind::Port);
+}
+
+TEST_CASE("NetlistGraph::lookup by name and range, overlapping", "[Netlist]") {
+  auto const &tree = R"(
+module m(input logic [7:0] a, output logic [7:0] b);
+  assign b = a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  // Port 'a' has bounds [0,7]. Query [3,5] overlaps.
+  auto results = test.graph.lookup("m.a", netlist::DriverBitRange(3, 5));
+  CHECK(results.size() == 1);
+  CHECK(results[0]->kind == NodeKind::Port);
+}
+
+TEST_CASE("NetlistGraph::lookup by name and range, non-overlapping",
+          "[Netlist]") {
+  auto const &tree = R"(
+module m(input logic [3:0] a, output logic [3:0] b);
+  assign b = a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  // Port 'a' has bounds [0,3]. Query [4,7] does not overlap.
+  auto results = test.graph.lookup("m.a", netlist::DriverBitRange(4, 7));
+  CHECK(results.empty());
+}
+
+TEST_CASE("NetlistGraph::lookup by name and range, non-existent name",
+          "[Netlist]") {
+  auto const &tree = R"(
+module m(input logic a, output logic b);
+  assign b = a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto results =
+      test.graph.lookup("m.nonexistent", netlist::DriverBitRange(0, 0));
+  CHECK(results.empty());
+}
+
+TEST_CASE("NetlistGraph::lookup by name and range returns multiple nodes",
+          "[Netlist]") {
+  // A sequential design creates both a Port node and a State node for 'b'.
+  auto const &tree = R"(
+module m(input clk, input logic a, output logic b);
+  always_ff @(posedge clk)
+    b <= a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto results = test.graph.lookup("m.b", netlist::DriverBitRange(0, 0));
+  // Should find both the output Port and the State node.
+  CHECK(results.size() == 2);
+  bool foundPort = false;
+  bool foundState = false;
+  for (auto *node : results) {
+    if (node->kind == NodeKind::Port)
+      foundPort = true;
+    if (node->kind == NodeKind::State)
+      foundState = true;
+  }
+  CHECK(foundPort);
+  CHECK(foundState);
+}


### PR DESCRIPTION
Add a `NetlistGraph::lookup(name, bounds)` overload that returns all `Port`/`Variable`/`State` nodes whose hierarchical path matches and whose bounds overlap the query range. Uses a lazily-built hash map index for O(1) name lookup, replacing the previous O(n) linear scan (which also now benefits from the index).

Add `getHierarchicalPath()` and `getBounds()` accessors to `NetlistNode` to eliminate repeated switch-over-kind patterns. Expose the new lookup as `lookup_by_range()` in the Python bindings.