### PR TITLE
Speed up DirectedGraph::addEdge with a per-node target index

### DIFF
--- a/include/netlist/DirectedGraph.hpp
+++ b/include/netlist/DirectedGraph.hpp
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <vector>
 
+#include "slang/util/FlatMap.h"
+
 namespace slang::netlist {
 
 /// A class to represent a directed edge in a graph.
@@ -115,28 +117,36 @@ public:
   /// Add an edge between this node and a target node, only if it does not
   /// already exist. Return a reference to the newly-created edge.
   ///
+  /// O(1) amortized: outEdgeIndex memoizes the first edge to each target,
+  /// avoiding the linear outEdges scan that becomes quadratic on
+  /// high-fan-out nodes (e.g. shared clocks driving every instance after
+  /// non-canonical-instance resolution).
+  ///
   /// Thread safety: safe to call concurrently. Lock ordering: source
   /// edgeMutex before target edgeMutex (self-edges use a single lock).
   auto addEdge(NodeType &targetNode) -> EdgeType & {
     bool isSelfEdge = (&getDerived() == &targetNode);
     std::lock_guard<std::mutex> lock(edgeMutex);
-    auto edgeIt = findEdgeTo(targetNode);
-    if (edgeIt == outEdges.end()) {
-      auto edge = std::make_shared<EdgeType>(getDerived(), targetNode);
-      outEdges.emplace_back(edge);
-      if (isSelfEdge) {
-        inEdges.push_back(edge);
-      } else {
-        std::lock_guard<std::mutex> lock2(targetNode.edgeMutex);
-        targetNode.inEdges.push_back(edge);
-      }
-      return *edge.get();
+    if (auto it = outEdgeIndex.find(&targetNode); it != outEdgeIndex.end()) {
+      return *it->second;
     }
-    return *((*edgeIt).get());
+    auto edge = std::make_shared<EdgeType>(getDerived(), targetNode);
+    outEdges.emplace_back(edge);
+    outEdgeIndex.emplace(&targetNode, edge.get());
+    if (isSelfEdge) {
+      inEdges.push_back(edge);
+    } else {
+      std::lock_guard<std::mutex> lock2(targetNode.edgeMutex);
+      targetNode.inEdges.push_back(edge);
+    }
+    return *edge.get();
   }
 
   /// Unconditionally add a new edge between this node and a target node,
-  /// even if one already exists (creating a parallel edge).
+  /// even if one already exists (creating a parallel edge). The
+  /// outEdgeIndex is left untouched: it points at the *first* edge to the
+  /// target, matching findEdgeTo's "first match wins" historical
+  /// semantics.
   ///
   /// Thread safety: safe to call concurrently. Lock ordering: source
   /// edgeMutex before target edgeMutex (self-edges use a single lock).
@@ -146,11 +156,16 @@ public:
     if (isSelfEdge) {
       std::lock_guard<std::mutex> lock(edgeMutex);
       outEdges.emplace_back(edge);
+      // If no entry exists yet (caller went straight to addNewEdge), seed
+      // it so a later addEdge dedupes against this edge instead of
+      // creating a third parallel one.
+      outEdgeIndex.try_emplace(&targetNode, edge.get());
       inEdges.push_back(edge);
     } else {
       {
         std::lock_guard<std::mutex> lock(edgeMutex);
         outEdges.emplace_back(edge);
+        outEdgeIndex.try_emplace(&targetNode, edge.get());
       }
       {
         std::lock_guard<std::mutex> lock(targetNode.edgeMutex);
@@ -168,6 +183,16 @@ public:
       auto success = targetNode.removeInEdge(getDerived());
       assert(success && "No corresponding in edge reference");
       outEdges.erase(edgeIt);
+      // Re-point or drop the index entry: a parallel edge to the same
+      // target may still survive in outEdges.
+      auto survivor = std::ranges::find_if(outEdges, [&](auto &e) {
+        return &e->getTargetNode() == &targetNode;
+      });
+      if (survivor == outEdges.end()) {
+        outEdgeIndex.erase(&targetNode);
+      } else {
+        outEdgeIndex[&targetNode] = survivor->get();
+      }
       return success;
     }
     return false;
@@ -180,6 +205,7 @@ public:
       edge->getTargetNode().removeInEdge(getDerived());
     }
     outEdges.clear();
+    outEdgeIndex.clear();
     // Remove incoming edges, creating a temporary list to avoid
     // invalidating the iterator.
     std::vector<NodeType *> sourceNodes;
@@ -223,6 +249,12 @@ protected:
 
   EdgeListType inEdges;
   EdgeListType outEdges;
+
+  /// Index from target-node pointer to the first edge in outEdges with
+  /// that target. Maintained by addEdge / addNewEdge / removeEdge /
+  /// clearAllEdges so addEdge stays O(1) amortized regardless of
+  /// out-degree. Protected by edgeMutex.
+  flat_hash_map<NodeType const *, EdgeType *> outEdgeIndex;
 
   // As the default implementation use address comparison for equality.
   auto isEqualTo(const NodeType &node) const -> bool { return this == &node; }

--- a/include/netlist/DirectedGraph.hpp
+++ b/include/netlist/DirectedGraph.hpp
@@ -145,8 +145,7 @@ public:
   /// Unconditionally add a new edge between this node and a target node,
   /// even if one already exists (creating a parallel edge). The
   /// outEdgeIndex is left untouched: it points at the *first* edge to the
-  /// target, matching findEdgeTo's "first match wins" historical
-  /// semantics.
+  /// target.
   ///
   /// Thread safety: safe to call concurrently. Lock ordering: source
   /// edgeMutex before target edgeMutex (self-edges use a single lock).

--- a/tests/unit/DirectedGraphTests.cpp
+++ b/tests/unit/DirectedGraphTests.cpp
@@ -238,3 +238,112 @@ TEST_CASE("Self-loop removal", "[DirectedGraph]") {
   CHECK(n0.inDegree() == 0);
   CHECK(n0.outDegree() == 0);
 }
+
+// addEdge after addNewEdge must return the *first* edge to the
+// target, not allocate a third — verifying that addNewEdge seeds the
+// outEdgeIndex when no entry exists yet.
+TEST_CASE("addEdge after addNewEdge returns the first edge",
+          "[DirectedGraph]") {
+  GraphType graph;
+  auto &n0 = graph.addNode();
+  auto &n1 = graph.addNode();
+  auto &first = n0.addNewEdge(n1);
+  auto &second = n0.addNewEdge(n1);
+  auto &dedup = n0.addEdge(n1);
+  CHECK(&dedup == &first);
+  CHECK(&dedup != &second);
+  CHECK(n0.outDegree() == 2); // The two parallel edges, no third.
+  CHECK(n1.inDegree() == 2);
+}
+
+// addNewEdge after addEdge correctly produces a parallel edge while
+// leaving the index pointing at the first edge.
+TEST_CASE("addNewEdge after addEdge keeps index on the original",
+          "[DirectedGraph]") {
+  GraphType graph;
+  auto &n0 = graph.addNode();
+  auto &n1 = graph.addNode();
+  auto &original = n0.addEdge(n1);
+  auto &parallel = n0.addNewEdge(n1);
+  CHECK(&original != &parallel);
+  CHECK(n0.outDegree() == 2);
+  // Subsequent addEdge must return the original, not the parallel.
+  auto &dedup = n0.addEdge(n1);
+  CHECK(&dedup == &original);
+  CHECK(n0.outDegree() == 2);
+}
+
+// removeEdge in the presence of parallel edges must re-point the
+// index at the surviving edge, so the next addEdge dedupes against it
+// instead of creating a new edge.
+TEST_CASE("removeEdge re-points index when a parallel edge survives",
+          "[DirectedGraph]") {
+  GraphType graph;
+  auto &n0 = graph.addNode();
+  auto &n1 = graph.addNode();
+  auto &first = n0.addEdge(n1);
+  auto &parallel = n0.addNewEdge(n1);
+  CHECK(graph.removeEdge(n0, n1));
+  CHECK(n0.outDegree() == 1);
+  // The first edge was removed (findEdgeTo returns the first match);
+  // the parallel one should be the survivor.
+  (void)first;
+  auto &dedup = n0.addEdge(n1);
+  CHECK(&dedup == &parallel);
+  CHECK(n0.outDegree() == 1);
+}
+
+// removeEdge of the only edge to a target must drop the index entry
+// so the next addEdge creates a fresh edge.
+TEST_CASE("removeEdge drops index entry when last edge to target removed",
+          "[DirectedGraph]") {
+  GraphType graph;
+  auto &n0 = graph.addNode();
+  auto &n1 = graph.addNode();
+  auto &first = n0.addEdge(n1);
+  CHECK(graph.removeEdge(n0, n1));
+  auto &fresh = n0.addEdge(n1);
+  CHECK(&fresh != &first);
+  CHECK(n0.outDegree() == 1);
+}
+
+// clearAllEdges must also reset the outEdgeIndex.
+TEST_CASE("clearAllEdges resets the dedup index", "[DirectedGraph]") {
+  GraphType graph;
+  auto &n0 = graph.addNode();
+  auto &n1 = graph.addNode();
+  auto &n2 = graph.addNode();
+  auto &original = n0.addEdge(n1);
+  n0.addEdge(n2);
+  n0.clearAllEdges();
+  CHECK(n0.outDegree() == 0);
+  // After clearing, addEdge must allocate a new edge — the old one
+  // must not be returned out of a stale index entry.
+  auto &fresh = n0.addEdge(n1);
+  CHECK(&fresh != &original);
+  CHECK(n0.outDegree() == 1);
+}
+
+// High fan-out smoke test: with the linear-scan dedup this would be
+// O(N²) in addEdge; with the hash-indexed path it is O(N) total. Caps
+// the design at a value that completes near-instantly with the index
+// and would visibly stall (>1s) without it.
+TEST_CASE("High fan-out addEdge stays linear", "[DirectedGraph]") {
+  constexpr size_t kFanOut = 20'000;
+  GraphType graph;
+  auto &source = graph.addNode();
+  std::vector<TestNode *> targets;
+  targets.reserve(kFanOut);
+  for (size_t i = 0; i < kFanOut; ++i) {
+    targets.push_back(&graph.addNode());
+  }
+  for (auto *t : targets) {
+    graph.addEdge(source, *t);
+  }
+  CHECK(source.outDegree() == kFanOut);
+  // Repeating the same calls must dedup, not duplicate.
+  for (auto *t : targets) {
+    graph.addEdge(source, *t);
+  }
+  CHECK(source.outDegree() == kFanOut);
+}

--- a/tests/unit/DirectedGraphTests.cpp
+++ b/tests/unit/DirectedGraphTests.cpp
@@ -294,33 +294,48 @@ TEST_CASE("removeEdge re-points index when a parallel edge survives",
 }
 
 // removeEdge of the only edge to a target must drop the index entry
-// so the next addEdge creates a fresh edge.
+// so the next addEdge actually adds (rather than returning a stale
+// pointer to the freed edge). We can't assert pointer inequality —
+// the allocator may legitimately reuse the slot — but we can assert
+// the graph is in the right shape and the new edge has live in/out
+// bookkeeping on both sides.
 TEST_CASE("removeEdge drops index entry when last edge to target removed",
           "[DirectedGraph]") {
   GraphType graph;
   auto &n0 = graph.addNode();
   auto &n1 = graph.addNode();
-  auto &first = n0.addEdge(n1);
+  n0.addEdge(n1);
   CHECK(graph.removeEdge(n0, n1));
-  auto &fresh = n0.addEdge(n1);
-  CHECK(&fresh != &first);
+  CHECK(n0.outDegree() == 0);
+  CHECK(n1.inDegree() == 0);
+  n0.addEdge(n1);
+  CHECK(n0.outDegree() == 1);
+  CHECK(n1.inDegree() == 1);
+  // A second addEdge must dedup against the now-current entry.
+  n0.addEdge(n1);
   CHECK(n0.outDegree() == 1);
 }
 
-// clearAllEdges must also reset the outEdgeIndex.
+// clearAllEdges must also reset the outEdgeIndex so subsequent
+// addEdge calls don't dedup against a stale entry.
 TEST_CASE("clearAllEdges resets the dedup index", "[DirectedGraph]") {
   GraphType graph;
   auto &n0 = graph.addNode();
   auto &n1 = graph.addNode();
   auto &n2 = graph.addNode();
-  auto &original = n0.addEdge(n1);
+  n0.addEdge(n1);
   n0.addEdge(n2);
   n0.clearAllEdges();
   CHECK(n0.outDegree() == 0);
-  // After clearing, addEdge must allocate a new edge — the old one
-  // must not be returned out of a stale index entry.
-  auto &fresh = n0.addEdge(n1);
-  CHECK(&fresh != &original);
+  CHECK(n1.inDegree() == 0);
+  CHECK(n2.inDegree() == 0);
+  // After clearing, addEdge must register the edge afresh — both the
+  // out-edge list and the in-edge list on the target need it back.
+  n0.addEdge(n1);
+  CHECK(n0.outDegree() == 1);
+  CHECK(n1.inDegree() == 1);
+  // And dedup is back in working order.
+  n0.addEdge(n1);
   CHECK(n0.outDegree() == 1);
 }
 


### PR DESCRIPTION
DirectedGraph::addEdge previously did a linear scan over outEdges
to dedup against existing edges to the same target. On nodes with
high fan-out (e.g. shared clocks driving every instance after
non-canonical-instance resolution) this turns N additions into O(N²) work.                          
                                                                               
Add a flat_hash_map<NodeType const*, EdgeType*> outEdgeIndex per node        
that points at the first edge to each target. addEdge becomes O(1)       
amortized; addNewEdge seeds the index when no entry exists yet so            
subsequent addEdge calls dedupe correctly; removeEdge re-points or           
drops the entry; clearAllEdges resets it.