### PR TITLE
Materialise procedural-block sensitivity as graph edges

### DIFF
--- a/include/netlist/CombLoops.hpp
+++ b/include/netlist/CombLoops.hpp
@@ -2,13 +2,15 @@
 
 #include "netlist/CycleDetector.hpp"
 #include "netlist/NetlistGraph.hpp"
+#include "netlist/NetlistNode.hpp"
 
 namespace slang::netlist {
 
 struct CombEdgePredicate {
   CombEdgePredicate() = default;
   bool operator()(const NetlistEdge &edge) {
-    return !edge.disabled && edge.edgeKind == ast::EdgeKind::None;
+    // Stop at the sequential boundary: edges into State are register inputs.
+    return !edge.disabled && edge.getTargetNode().kind != NodeKind::State;
   }
 };
 

--- a/include/netlist/NetlistGraph.hpp
+++ b/include/netlist/NetlistGraph.hpp
@@ -8,6 +8,8 @@
 #include "netlist/NetlistNode.hpp"
 #include "netlist/TextLocation.hpp"
 
+#include "slang/ast/SemanticFacts.h"
+
 #include <algorithm>
 #include <ranges>
 #include <regex>
@@ -73,6 +75,20 @@ public:
   /// backward (fan-in) direction.  The traversal stops at State nodes.
   [[nodiscard]] auto getCombFanIn(NetlistNode &node) const
       -> std::vector<NetlistNode *>;
+
+  /// A clock/reset signal driving a State node, paired with its edge kind.
+  struct SensitivitySource {
+    NetlistNode *source;
+    ast::EdgeKind edgeKind;
+
+    auto operator==(SensitivitySource const &) const -> bool = default;
+  };
+
+  /// Clocks gating @p node: own edges for a State, otherwise the union of
+  /// sensitivity over every State reachable by combinational fan-out.
+  /// Deduplicated on (source, edgeKind).
+  [[nodiscard]] auto getSensitivity(NetlistNode &node) const
+      -> std::vector<SensitivitySource>;
 
   /// Find named nodes whose hierarchical path matches the wildcard @p pattern.
   /// Supports '*' (zero or more characters) and '?' (one character).

--- a/source/NetlistBuilder.cpp
+++ b/source/NetlistBuilder.cpp
@@ -6,7 +6,9 @@
 
 #include "slang/ast/EvalContext.h"
 #include "slang/ast/HierarchicalReference.h"
+#include "slang/ast/TimingControl.h"
 #include "slang/ast/ValuePath.h"
+#include "slang/ast/expressions/MiscExpressions.h"
 #include "slang/ast/symbols/BlockSymbols.h"
 #include "slang/ast/symbols/InstanceSymbols.h"
 
@@ -109,58 +111,57 @@ auto NetlistBuilder::getDriverPathName(ast::ValueSymbol const &symbol,
   return driver.path.toString(evalContext);
 }
 
-auto NetlistBuilder::determineEdgeKind(ast::ProceduralBlockSymbol const &symbol)
-    -> ast::EdgeKind {
-  ast::EdgeKind result = ast::EdgeKind::None;
+auto NetlistBuilder::collectSensitivity(
+    ast::ProceduralBlockSymbol const &symbol) -> SmallVector<SensitivityEntry> {
+  SmallVector<SensitivityEntry> result;
 
-  if (symbol.procedureKind == ast::ProceduralBlockKind::AlwaysFF ||
-      symbol.procedureKind == ast::ProceduralBlockKind::Always) {
+  if (symbol.procedureKind != ast::ProceduralBlockKind::AlwaysFF &&
+      symbol.procedureKind != ast::ProceduralBlockKind::Always) {
+    return result;
+  }
 
-    if (symbol.getBody().kind == ast::StatementKind::Block) {
-      auto const &block = symbol.getBody().as<ast::BlockStatement>();
-
-      if (block.blockKind == ast::StatementBlockKind::Sequential &&
-          block.body.kind == ast::StatementKind::ConcurrentAssertion) {
-        return result;
-      }
-    }
-
-    if (symbol.getBody().kind != ast::StatementKind::Timed) {
+  if (symbol.getBody().kind == ast::StatementKind::Block) {
+    auto const &block = symbol.getBody().as<ast::BlockStatement>();
+    if (block.blockKind == ast::StatementBlockKind::Sequential &&
+        block.body.kind == ast::StatementKind::ConcurrentAssertion) {
       return result;
-    }
-
-    auto tck = symbol.getBody().as<ast::TimedStatement>().timing.kind;
-
-    if (tck == ast::TimingControlKind::SignalEvent) {
-      result = symbol.getBody()
-                   .as<ast::TimedStatement>()
-                   .timing.as<ast::SignalEventControl>()
-                   .edge;
-
-    } else if (tck == ast::TimingControlKind::EventList) {
-
-      auto const &events = symbol.getBody()
-                               .as<ast::TimedStatement>()
-                               .timing.as<ast::EventListControl>()
-                               .events;
-
-      // We need to decide if this has the potential for combinational loops
-      // The most strict test is if for any unique signal on the event list
-      // only one edge (pos or neg) appears e.g. "@(posedge x or negedge x)"
-      // is potentially combinational. At the moment we'll settle for no
-      // signal having "None" edge.
-
-      for (auto const &e : events) {
-        result = e->as<ast::SignalEventControl>().edge;
-        if (result == ast::EdgeKind::None) {
-          break;
-        }
-      }
-
-      // If we got here, edgeKind is not "None" which is all we care about.
     }
   }
 
+  if (symbol.getBody().kind != ast::StatementKind::Timed) {
+    return result;
+  }
+
+  auto const &timing = symbol.getBody().as<ast::TimedStatement>().timing;
+
+  bool sawCombEvent = false;
+
+  auto recordEvent = [&](ast::SignalEventControl const &sec) {
+    // Any unqualified event (`always @(x or y)`) demotes the block to
+    // combinational.
+    if (sec.edge == ast::EdgeKind::None) {
+      sawCombEvent = true;
+      return;
+    }
+    // Skip non-symbol event expressions; the State node still captures
+    // the sequential nature.
+    if (ast::ValueExpressionBase::isKind(sec.expr.kind)) {
+      auto const &valExpr = sec.expr.as<ast::ValueExpressionBase>();
+      result.push_back({&valExpr.symbol, &sec.expr, sec.edge});
+    }
+  };
+
+  if (timing.kind == ast::TimingControlKind::SignalEvent) {
+    recordEvent(timing.as<ast::SignalEventControl>());
+  } else if (timing.kind == ast::TimingControlKind::EventList) {
+    for (auto const *e : timing.as<ast::EventListControl>().events) {
+      recordEvent(e->as<ast::SignalEventControl>());
+    }
+  }
+
+  if (sawCombEvent) {
+    return {};
+  }
   return result;
 }
 
@@ -276,8 +277,7 @@ void NetlistBuilder::addRvalue(ast::EvalContext &evalCtx,
 
 void NetlistBuilder::hookupOutputPort(ast::ValueSymbol const &symbol,
                                       DriverBitRange bounds,
-                                      DriverList const &driverList,
-                                      ast::EdgeKind edgeKind) {
+                                      DriverList const &driverList) {
 
   // If there is an output port associated with this symbol, then add a
   // dependency from the driver to the port.
@@ -311,18 +311,20 @@ void NetlistBuilder::hookupOutputPort(ast::ValueSymbol const &symbol,
       auto symRef = toSymbolRef(symbol);
       for (auto const &driver : driverList) {
         if (driver.node != nullptr) {
-          addDependency(*driver.node, *portNode, symRef, bounds, edgeKind);
+          addDependency(*driver.node, *portNode, symRef, bounds);
         }
       }
     }
   }
 }
 
-void NetlistBuilder::mergeDrivers(ast::EvalContext &evalCtx,
-                                  ValueTracker const &valueTracker,
-                                  ValueDrivers const &valueDrivers,
-                                  ast::EdgeKind edgeKind) {
+void NetlistBuilder::mergeDrivers(
+    ast::EvalContext &evalCtx, ValueTracker const &valueTracker,
+    ValueDrivers const &valueDrivers,
+    std::span<SensitivityEntry const> sensitivity) {
   DEBUG_PRINT("Merging procedural drivers\n");
+
+  bool const isSequential = !sensitivity.empty();
 
   valueTracker.visitAll([&](const ast::ValueSymbol *symbol, uint32_t index) {
     DEBUG_PRINT("Symbol {} at index={}\n", symbol->name, index);
@@ -346,9 +348,9 @@ void NetlistBuilder::mergeDrivers(ast::EvalContext &evalCtx,
       auto const &driverList = valueDrivers[index].getDriverList(*it);
       auto const &valueSymbol = symbol->as<ast::ValueSymbol>();
 
-      if (edgeKind == ast::EdgeKind::None) {
+      if (!isSequential) {
 
-        // Combinational edge, so just add the interval with the driving
+        // Combinational block, so just add the interval with the driving
         // node(s).
         mergeDrivers(*symbol, it.bounds(), driverList);
 
@@ -356,23 +358,34 @@ void NetlistBuilder::mergeDrivers(ast::EvalContext &evalCtx,
 
       } else {
 
-        // Sequential edge, so the procedural drivers act on a stateful
-        // variable which is represented by a node in the graph. We create
-        // this node, add edges from the procedural drivers to it, and then
-        // add the state node as the new driver for the range.
+        // Sequential: create a State node, wire data drivers to it, and
+        // attach a clock edge per sensitivity entry. The State becomes
+        // the new driver for the range.
 
         auto &stateNode = nodeFactory.createState(valueSymbol, it.bounds());
 
         auto symRef = toSymbolRef(*symbol);
         for (auto const &driver : driverList) {
           if (driver.node != nullptr) {
-            addDependency(*driver.node, stateNode, symRef, it.bounds(),
-                          edgeKind);
+            addDependency(*driver.node, stateNode, symRef, it.bounds());
           }
         }
 
+        // Route each clock through the pending-rvalue resolver so input
+        // ports, internal wires, gated clocks, and clock dividers all
+        // hook up via the same driver-walk used for ordinary r-values.
+        for (auto const &entry : sensitivity) {
+          auto width = entry.signal->getType().getSelectableWidth();
+          if (width == 0) {
+            continue;
+          }
+          DriverBitRange sigBounds{0, static_cast<int32_t>(width - 1)};
+          pendingQueue.enqueue(*entry.signal, *entry.lsp, sigBounds, &stateNode,
+                               entry.edgeKind);
+        }
+
         hookupOutputPort(valueSymbol, it.bounds(),
-                         {{.node = &stateNode, .lsp = nullptr}}, edgeKind);
+                         {{.node = &stateNode, .lsp = nullptr}});
       }
 
       auto symRef = toSymbolRef(*symbol);
@@ -484,12 +497,12 @@ void NetlistBuilder::handle(ast::ContinuousAssignSymbol const &symbol) {
 void NetlistBuilder::handleProceduralBlock(
     ast::ProceduralBlockSymbol const &symbol) {
   DEBUG_PRINT("ProceduralBlock\n");
-  auto edgeKind = determineEdgeKind(symbol);
+  auto sensitivity = collectSensitivity(symbol);
   auto dfa = std::make_shared<DataFlowAnalysis>(analysisManager, symbol, *this);
   dfa->run(symbol.as<ast::ProceduralBlockSymbol>().getBody());
   dfa->finalize();
   mergeDrivers(dfa->getEvalContext(), dfa->valueTracker,
-               dfa->getState().valueDrivers, edgeKind);
+               dfa->getState().valueDrivers, sensitivity);
 }
 
 void NetlistBuilder::handleContinuousAssign(
@@ -498,7 +511,7 @@ void NetlistBuilder::handleContinuousAssign(
   auto dfa = std::make_shared<DataFlowAnalysis>(analysisManager, symbol, *this);
   dfa->run(symbol.getAssignment());
   mergeDrivers(dfa->getEvalContext(), dfa->valueTracker,
-               dfa->getState().valueDrivers, ast::EdgeKind::None);
+               dfa->getState().valueDrivers);
 }
 
 void NetlistBuilder::handle(ast::GenerateBlockSymbol const &symbol) {

--- a/source/NetlistBuilder.hpp
+++ b/source/NetlistBuilder.hpp
@@ -148,10 +148,19 @@ private:
                                 analysis::ValueDriver const &driver)
       -> std::string;
 
-  /// Determine the edge type to apply within a procedural
-  /// block.
-  static auto determineEdgeKind(ast::ProceduralBlockSymbol const &symbol)
-      -> ast::EdgeKind;
+  /// One event-list entry: signal symbol, its LSP expression, and edge
+  /// kind. Non-symbol expressions (bit-selects, arithmetic) are dropped.
+  struct SensitivityEntry {
+    ast::ValueSymbol const *signal;
+    ast::Expression const *lsp;
+    ast::EdgeKind edgeKind;
+  };
+
+  /// Per-signal sensitivity from a procedural block's event list. Empty
+  /// when the block is combinational (no timing control or any unqualified
+  /// event).
+  static auto collectSensitivity(ast::ProceduralBlockSymbol const &symbol)
+      -> SmallVector<SensitivityEntry>;
 
   auto getVariable(ast::Symbol const &symbol, DriverBitRange bounds)
       -> NetlistNode * {
@@ -211,8 +220,7 @@ private:
   /// the drivers to the port node. This is called when merging driver into
   /// the graph.
   void hookupOutputPort(ast::ValueSymbol const &symbol, DriverBitRange bounds,
-                        DriverList const &driverList,
-                        ast::EdgeKind edgeKind = ast::EdgeKind::None);
+                        DriverList const &driverList);
 
   /// Add a driver for the specified symbol.
   /// This overwrites any existing drivers for the specified bit range.
@@ -228,11 +236,13 @@ private:
     driverMap.addDrivers(drivers, symbol, bounds, driverList, /*merge=*/true);
   }
 
-  /// Merge symbol drivers from a procedural data flow analysis into the
-  /// central driver tracker.
+  /// Merge procedural drivers into the central tracker. Non-empty
+  /// @p sensitivity makes the block sequential: each driven range gets a
+  /// State node, with data edges from drivers and a clock edge per
+  /// sensitivity entry.
   void mergeDrivers(ast::EvalContext &evalCtx, ValueTracker const &valueTracker,
                     ValueDrivers const &valueDrivers,
-                    ast::EdgeKind edgeKind = ast::EdgeKind::None);
+                    std::span<SensitivityEntry const> sensitivity = {});
 };
 
 } // namespace slang::netlist

--- a/source/NetlistGraph.cpp
+++ b/source/NetlistGraph.cpp
@@ -129,6 +129,59 @@ auto NetlistGraph::getCombFanIn(NetlistNode &node) const
   return result;
 }
 
+auto NetlistGraph::getSensitivity(NetlistNode &node) const
+    -> std::vector<SensitivitySource> {
+  std::vector<SensitivitySource> result;
+
+  auto collectFromState = [&](NetlistNode &state) {
+    SLANG_ASSERT(state.kind == NodeKind::State);
+    for (auto const &edge : state.getInEdges()) {
+      if (edge->disabled || edge->edgeKind == ast::EdgeKind::None) {
+        continue;
+      }
+      auto *source = &edge->getSourceNode();
+      auto duplicate =
+          std::any_of(result.begin(), result.end(), [&](auto const &existing) {
+            return existing.source == source &&
+                   existing.edgeKind == edge->edgeKind;
+          });
+      if (!duplicate) {
+        result.push_back({source, edge->edgeKind});
+      }
+    }
+  };
+
+  if (node.kind == NodeKind::State) {
+    collectFromState(node);
+    return result;
+  }
+
+  // Forward walk: collect State targets without traversing into them.
+  // getCombFanOut can't be reused — its predicate drops edges-to-State.
+  std::unordered_set<NetlistNode *> visited;
+  std::vector<NetlistNode *> stack;
+  visited.insert(&node);
+  stack.push_back(&node);
+  while (!stack.empty()) {
+    auto *cur = stack.back();
+    stack.pop_back();
+    for (auto const &edge : cur->getOutEdges()) {
+      if (edge->disabled) {
+        continue;
+      }
+      auto &target = edge->getTargetNode();
+      if (target.kind == NodeKind::State) {
+        collectFromState(target);
+        continue;
+      }
+      if (visited.insert(&target).second) {
+        stack.push_back(&target);
+      }
+    }
+  }
+  return result;
+}
+
 auto NetlistGraph::findNodes(std::string_view pattern) const
     -> std::vector<NetlistNode *> {
   buildIndex();

--- a/source/PendingRValue.hpp
+++ b/source/PendingRValue.hpp
@@ -2,6 +2,7 @@
 
 #include "netlist/NetlistGraph.hpp"
 
+#include "slang/ast/SemanticFacts.h"
 #include "slang/ast/symbols/ValueSymbol.h"
 
 #include <utility>
@@ -22,9 +23,15 @@ struct PendingRvalue {
   // The operation in which the rvalue appears.
   NetlistNode *node{nullptr};
 
+  // Edge kind to stamp on the resolved edge. Non-None marks this rvalue
+  // as a clocking/reset signal from an event list.
+  ast::EdgeKind edgeKind{ast::EdgeKind::None};
+
   PendingRvalue(const ast::ValueSymbol *symbol, const ast::Expression *lsp,
-                DriverBitRange bounds, NetlistNode *node)
-      : symbol(symbol), lsp(lsp), bounds(std::move(bounds)), node(node) {}
+                DriverBitRange bounds, NetlistNode *node,
+                ast::EdgeKind edgeKind = ast::EdgeKind::None)
+      : symbol(symbol), lsp(lsp), bounds(std::move(bounds)), node(node),
+        edgeKind(edgeKind) {}
 };
 
 } // namespace slang::netlist

--- a/source/PendingRvalueQueue.cpp
+++ b/source/PendingRvalueQueue.cpp
@@ -20,12 +20,13 @@ thread_local DeferredGraphWork *threadLocalDeferredWork = nullptr;
 
 void PendingRvalueQueue::enqueue(ast::ValueSymbol const &symbol,
                                  ast::Expression const &lsp,
-                                 DriverBitRange bounds, NetlistNode *node) {
+                                 DriverBitRange bounds, NetlistNode *node,
+                                 ast::EdgeKind edgeKind) {
   if (threadLocalDeferredWork) {
     threadLocalDeferredWork->pendingRValues.emplace_back(&symbol, &lsp, bounds,
-                                                         node);
+                                                         node, edgeKind);
   } else {
-    queue.emplace_back(&symbol, &lsp, bounds, node);
+    queue.emplace_back(&symbol, &lsp, bounds, node, edgeKind);
   }
 }
 
@@ -56,7 +57,8 @@ void PendingRvalueQueue::emitEdgesFor(PendingRvalue const &pending) {
 
   // If there is state variable matching this rvalue.
   if (auto *stateNode = builder.getVariable(*pending.symbol, pending.bounds)) {
-    builder.addDependency(*stateNode, *pending.node, symRef, pending.bounds);
+    builder.addDependency(*stateNode, *pending.node, symRef, pending.bounds,
+                          pending.edgeKind);
     return;
   }
 
@@ -77,7 +79,7 @@ void PendingRvalueQueue::emitEdgesFor(PendingRvalue const &pending) {
         for (auto const &source : driverList) {
           if (source.node != nullptr) {
             builder.addDependency(*source.node, *pending.node, symRef,
-                                  *edgeBounds);
+                                  *edgeBounds, pending.edgeKind);
           }
         }
       });

--- a/source/PendingRvalueQueue.hpp
+++ b/source/PendingRvalueQueue.hpp
@@ -35,9 +35,13 @@ public:
   explicit PendingRvalueQueue(NetlistBuilder &builder) : builder(builder) {}
 
   /// Push a pending R-value onto either the current task's
-  /// thread-local buffer (if one is set) or the main queue.
+  /// thread-local buffer (if one is set) or the main queue. @p edgeKind
+  /// is forwarded to the resolved edge; pass `None` for ordinary r-values
+  /// and `PosEdge`/`NegEdge`/`BothEdges` for procedural-block sensitivity
+  /// signals.
   void enqueue(ast::ValueSymbol const &symbol, ast::Expression const &lsp,
-               DriverBitRange bounds, NetlistNode *node);
+               DriverBitRange bounds, NetlistNode *node,
+               ast::EdgeKind edgeKind = ast::EdgeKind::None);
 
   /// Set or clear the current thread's per-task buffer. Pass nullptr
   /// to revert to the shared-queue path.

--- a/tests/unit/BugTests.cpp
+++ b/tests/unit/BugTests.cpp
@@ -112,6 +112,7 @@ endmodule
   N4 [label="Assignment"]
   N5 [label="Assignment"]
   N6 [label="nq [31:0]"]
+  N1 -> N6 [label="clk[0]"]
   N4 -> N4 [label="n[31:0]"]
   N4 -> N5 [label="n[31:0]"]
   N5 -> N6 [label="nq[31:0]"]

--- a/tests/unit/PortTests.cpp
+++ b/tests/unit/PortTests.cpp
@@ -89,7 +89,9 @@ endmodule
   N8 [label="Assignment"]
   N9 [label="Merge"]
   N10 [label="foo_q [0]"]
+  N1 -> N10 [label="clk[0]"]
   N2 -> N5 [label="rst[0]"]
+  N2 -> N10 [label="rst[0]"]
   N3 -> N8 [label="foo[0]"]
   N5 -> N6
   N5 -> N8

--- a/tests/unit/SequentialStateTests.cpp
+++ b/tests/unit/SequentialStateTests.cpp
@@ -16,6 +16,7 @@ TEST_CASE("Assigning to a variable", "[SequentialState]") {
   N2 [label="In port a"]
   N3 [label="Assignment"]
   N4 [label="b [0]"]
+  N1 -> N4 [label="clk[0]"]
   N2 -> N3 [label="a[0]"]
   N3 -> N4 [label="b[0]"]
 }
@@ -47,7 +48,9 @@ TEST_CASE("Two control paths assigning to the same variable",
   N8 [label="Assignment"]
   N9 [label="Merge"]
   N10 [label="b [0]"]
+  N1 -> N10 [label="clk[0]"]
   N2 -> N5 [label="rst[0]"]
+  N2 -> N10 [label="rst[0]"]
   N3 -> N8 [label="a[0]"]
   N5 -> N6
   N5 -> N8
@@ -85,7 +88,9 @@ endmodule
   N8 [label="Assignment"]
   N9 [label="Merge"]
   N10 [label="b [0]"]
+  N1 -> N10 [label="clk[0]"]
   N2 -> N5 [label="rst[0]"]
+  N2 -> N10 [label="rst[0]"]
   N3 -> N8 [label="a[0]"]
   N5 -> N6
   N5 -> N8
@@ -192,6 +197,8 @@ endmodule
   N15 [label="Merge"]
   N16 [label="foo_q [0]"]
   N17 [label="valid_q [0]"]
+  N1 -> N16 [label="clk[0]"]
+  N1 -> N17 [label="clk[0]"]
   N2 -> N6 [label="rst[0]"]
   N3 -> N12 [label="foo[0]"]
   N4 -> N14 [label="ready[0]"]
@@ -211,4 +218,226 @@ endmodule
   N17 -> N11 [label="valid_q[0]"]
 }
 )");
+}
+
+namespace {
+
+// Edges (driverPath -> State stateName) tagged with @p kind.
+auto countSensitivityEdges(NetlistGraph const &graph,
+                           std::string_view driverPath,
+                           std::string_view stateName, ast::EdgeKind kind)
+    -> size_t {
+  size_t count = 0;
+  for (auto const &node : graph) {
+    auto path = node->getHierarchicalPath();
+    if (!path || *path != driverPath) {
+      continue;
+    }
+    for (auto const &edge : node->getOutEdges()) {
+      auto const &target = edge->getTargetNode();
+      if (target.kind != NodeKind::State) {
+        continue;
+      }
+      auto targetPath = target.getHierarchicalPath();
+      if (!targetPath || *targetPath != stateName) {
+        continue;
+      }
+      if (edge->edgeKind == kind) {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+} // namespace
+
+TEST_CASE("Sensitivity: posedge clk drives a single PosEdge edge into State",
+          "[SequentialState][Sensitivity]") {
+  auto const &tree = R"(
+module m(input clk, input logic a, output logic b);
+  always_ff @(posedge clk)
+    b <= a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  CHECK(countSensitivityEdges(test.graph, "m.clk", "m.b",
+                              ast::EdgeKind::PosEdge) == 1);
+  CHECK(countSensitivityEdges(test.graph, "m.clk", "m.b",
+                              ast::EdgeKind::None) == 0);
+}
+
+TEST_CASE("Sensitivity: posedge clk + negedge rst_n produces both edges",
+          "[SequentialState][Sensitivity]") {
+  auto const &tree = R"(
+module m(input clk, input rst_n, input logic a, output logic b);
+  always_ff @(posedge clk or negedge rst_n)
+    if (!rst_n)
+      b <= '0;
+    else
+      b <= a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  CHECK(countSensitivityEdges(test.graph, "m.clk", "m.b",
+                              ast::EdgeKind::PosEdge) == 1);
+  CHECK(countSensitivityEdges(test.graph, "m.rst_n", "m.b",
+                              ast::EdgeKind::NegEdge) == 1);
+}
+
+TEST_CASE("Sensitivity: gated clock fans in through its combinational driver",
+          "[SequentialState][Sensitivity]") {
+  // Clock built from `clk & en`: the sensitivity edge lands on the gating
+  // assignment, and clk/en remain reachable upstream.
+  auto const &tree = R"(
+module m(input clk, input en, input logic a, output logic b);
+  wire gclk;
+  assign gclk = clk & en;
+  always_ff @(posedge gclk)
+    b <= a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  CHECK(test.pathExists("m.clk", "m.b"));
+  CHECK(test.pathExists("m.en", "m.b"));
+  CHECK(test.pathExists("m.a", "m.b"));
+  // At least one PosEdge edge feeds the State.
+  size_t posEdgeIntoState = 0;
+  for (auto const &node : test.graph) {
+    if (node->kind != NodeKind::State) {
+      continue;
+    }
+    auto path = node->getHierarchicalPath();
+    if (!path || *path != "m.b") {
+      continue;
+    }
+    for (auto const &edge : node->getInEdges()) {
+      if (edge->edgeKind == ast::EdgeKind::PosEdge) {
+        posEdgeIntoState++;
+      }
+    }
+  }
+  CHECK(posEdgeIntoState >= 1);
+}
+
+TEST_CASE("getSensitivity: returns clk/rst for State node",
+          "[SequentialState][Sensitivity]") {
+  auto const &tree = R"(
+module m(input clk, input rst_n, input logic a, output logic b);
+  always_ff @(posedge clk or negedge rst_n)
+    if (!rst_n) b <= '0;
+    else        b <= a;
+endmodule
+)";
+  const NetlistTest test(tree);
+  NetlistNode *stateB = nullptr;
+  for (auto const &node : test.graph) {
+    if (node->kind == NodeKind::State) {
+      auto path = node->getHierarchicalPath();
+      if (path && std::string(*path) == "m.b") {
+        stateB = node.get();
+        break;
+      }
+    }
+  }
+  REQUIRE(stateB != nullptr);
+
+  auto sources = test.graph.getSensitivity(*stateB);
+  REQUIRE(sources.size() == 2);
+
+  bool sawPosClk = false, sawNegRst = false;
+  for (auto const &s : sources) {
+    auto path = s.source->getHierarchicalPath();
+    REQUIRE(path.has_value());
+    std::string p(*path);
+    if (p == "m.clk" && s.edgeKind == ast::EdgeKind::PosEdge) {
+      sawPosClk = true;
+    }
+    if (p == "m.rst_n" && s.edgeKind == ast::EdgeKind::NegEdge) {
+      sawNegRst = true;
+    }
+  }
+  CHECK(sawPosClk);
+  CHECK(sawNegRst);
+}
+
+TEST_CASE("getSensitivity: upstream comb node inherits sensitivity from "
+          "the State it feeds",
+          "[SequentialState][Sensitivity]") {
+  // Input feeding a flop through comb logic reports the downstream clock.
+  auto const &tree = R"(
+module m(input clk, input logic a, input logic b, output logic q);
+  logic tmp;
+  assign tmp = a ^ b;
+  always_ff @(posedge clk)
+    q <= tmp;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto *aPort = test.graph.lookup("m.a");
+  REQUIRE(aPort != nullptr);
+
+  auto sources = test.graph.getSensitivity(*aPort);
+  REQUIRE(sources.size() == 1);
+  CHECK(sources[0].edgeKind == ast::EdgeKind::PosEdge);
+  auto path = sources[0].source->getHierarchicalPath();
+  REQUIRE(path.has_value());
+  CHECK(std::string(*path) == "m.clk");
+}
+
+TEST_CASE("getSensitivity: pure combinational node returns empty",
+          "[SequentialState][Sensitivity]") {
+  auto const &tree = R"(
+module m(input logic a, input logic b, output logic z);
+  assign z = a & b;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto *aPort = test.graph.lookup("m.a");
+  REQUIRE(aPort != nullptr);
+  CHECK(test.graph.getSensitivity(*aPort).empty());
+}
+
+TEST_CASE("getSensitivity: dedupes when one comb node feeds two flops on "
+          "the same clock",
+          "[SequentialState][Sensitivity]") {
+  auto const &tree = R"(
+module m(input clk, input logic a, output logic q1, output logic q2);
+  logic tmp;
+  assign tmp = ~a;
+  always_ff @(posedge clk) begin
+    q1 <= tmp;
+    q2 <= tmp;
+  end
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto *aPort = test.graph.lookup("m.a");
+  REQUIRE(aPort != nullptr);
+
+  // Two State targets, one (clk, PosEdge) entry after dedupe.
+  auto sources = test.graph.getSensitivity(*aPort);
+  REQUIRE(sources.size() == 1);
+  CHECK(sources[0].edgeKind == ast::EdgeKind::PosEdge);
+}
+
+TEST_CASE("Sensitivity: combinational always with no edges has no PosEdge "
+          "and no State node",
+          "[SequentialState][Sensitivity]") {
+  // `always @(x or y)` is combinational: no State, no edge-qualified edges.
+  auto const &tree = R"(
+module m(input logic x, input logic y, output logic z);
+  always @(x or y)
+    z = x ^ y;
+endmodule
+)";
+  const NetlistTest test(tree);
+  for (auto const &node : test.graph) {
+    CHECK(node->kind != NodeKind::State);
+    for (auto const &edge : node->getOutEdges()) {
+      CHECK(edge->edgeKind == ast::EdgeKind::None);
+    }
+  }
+  CHECK(test.pathExists("m.x", "m.z"));
+  CHECK(test.pathExists("m.y", "m.z"));
 }


### PR DESCRIPTION
Replace the per-procedural-block "is sequential" EdgeKind with per-signal clock/reset edges into the State node. Each event in an always_ff/always event list now becomes a Variable→State (or Port→State, or Assignment→State for gated clocks) edge whose NetlistEdge::edgeKind carries that signal's PosEdge/NegEdge/BothEdges sensitivity. Data-driver edges into State revert to EdgeKind::None.

Sensitivity sources are routed through the existing PendingRvalue resolver, so input ports, internal wires, gated clocks, and clock-divider state outputs all hook up via the same driver-interval walk used for ordinary r-values. PendingRvalue gains an optional edgeKind field that the resolver forwards to addDependency.

CombLoops now breaks combinational traversal at the State-node boundary (target.kind != NodeKind::State) rather than relying on edgeKind on data edges, since data edges into State are no longer stamped.

`always @(x or y)` (event without a posedge/negedge qualifier) is still treated as combinational: collectSensitivity returns an empty list when any event lacks an edge qualifier.