### PR TITLE
Add black-box coverage classification on NetlistGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+Library features:
+* Record the resolved hierarchical path of each black-boxed instance on the
+  graph (`NetlistGraph::getBlackBoxPaths`) and add
+  `NetlistGraph::getBlackBoxCoverage(NetlistNode const&)`, which classifies
+  any node as outside, on the boundary of, or contained in a black box.
+
+Library changes:
+* Bump the netlist JSON format to version 3: black-box instance paths are
+  serialised in a new `blackBoxes` field.
+
 ## [v0.10.0]
 
 Library features:

--- a/docs/developer-guide.dox
+++ b/docs/developer-guide.dox
@@ -558,6 +558,21 @@ Cross-port cut propagation still runs first, so a concat-shaped
 actual against a black-boxed instance produces the same per-bit
 formal port nodes it would for a fully-elaborated instance.
 
+Each matched instance's resolved hierarchical path is recorded on the
+graph via @c NetlistGraph::addBlackBoxPath. This converts the
+pattern-world (globs over definition names and paths) into concrete
+instance paths at the only point where both are known, so subsequent
+queries need neither the AST nor the original patterns.
+@c NetlistGraph::getBlackBoxCoverage classifies any node against the
+recorded paths by segment-aware prefix matching on its hierarchical
+path: a Port node directly below a black-boxed instance is on the
+boundary (@c BlackBoxCoverage::Boundary), any other node at or below
+one is contained (@c Contained), and everything else — including nodes
+without a hierarchical path — is outside (@c Outside). Containment
+takes precedence over the boundary when boxes nest. The paths are
+serialised in the JSON format (the @c blackBoxes field), so coverage
+queries also work on deserialised graphs.
+
 @subsection internals-limitations Known limitations
 
 The bit-aligned path falls back to @c handleAssignmentLegacy /

--- a/include/netlist/NetlistGraph.hpp
+++ b/include/netlist/NetlistGraph.hpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <ranges>
 #include <regex>
+#include <span>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -28,6 +29,16 @@ class AnalysisManager;
 } // namespace slang
 
 namespace slang::netlist {
+
+/// Classification of a node against a graph's black boxes.
+enum class BlackBoxCoverage {
+  /// Not covered by any black box.
+  Outside,
+  /// A port of a black-boxed instance.
+  Boundary,
+  /// Strictly inside a black box.
+  Contained,
+};
 
 /// Represent the netlist connectivity of an elaborated design.
 class NetlistGraph : public DirectedGraph<NetlistNode, NetlistEdge> {
@@ -144,8 +155,28 @@ public:
   /// Set the profiling data (called internally by NetlistBuilder).
   void setBuildProfile(BuildProfile const &profile) { buildProfile = profile; }
 
+  /// Record the hierarchical path of a black-boxed instance.
+  void addBlackBoxPath(std::string path) {
+    blackBoxPaths.push_back(std::move(path));
+  }
+
+  /// Return the hierarchical paths of the black-boxed instances.
+  [[nodiscard]] auto getBlackBoxPaths() const -> std::span<std::string const> {
+    return blackBoxPaths;
+  }
+
+  /// Classify a node against the recorded black-box instance paths.
+  ///
+  /// A Port node directly below a black-boxed instance is on the boundary;
+  /// any other node at or below a black-boxed instance is contained.
+  /// Nodes with no hierarchical path, or outside every box, are outside.
+  /// Containment takes precedence over the boundary when boxes nest.
+  [[nodiscard]] auto getBlackBoxCoverage(NetlistNode const &node) const
+      -> BlackBoxCoverage;
+
 private:
   BuildProfile buildProfile;
+  std::vector<std::string> blackBoxPaths;
   mutable bool indexBuilt = false;
   mutable std::unordered_map<std::string, std::vector<NetlistNode *>> nodeIndex;
   void buildIndex() const;

--- a/include/netlist/NetlistSerializer.hpp
+++ b/include/netlist/NetlistSerializer.hpp
@@ -9,11 +9,12 @@ namespace slang::netlist {
 
 /// Serialise and deserialise a NetlistGraph to/from JSON.
 ///
-/// Format (version 2):
+/// Format (version 3):
 /// @code{.json}
 /// {
-///   "version": 2,
+///   "version": 3,
 ///   "fileTable": ["test.sv", "other.sv"],
+///   "blackBoxes": ["m.u_core"],
 ///   "nodes": [
 ///     {"id": 1, "kind": "Port", "path": "m.a", "name": "a",
 ///      "bounds": [0, 0], "direction": "In",
@@ -28,7 +29,7 @@ namespace slang::netlist {
 /// }
 /// @endcode
 struct NetlistSerializer {
-  static constexpr int formatVersion = 2;
+  static constexpr int formatVersion = 3;
 
   /// Serialise @p graph to a pretty-printed JSON string.
   static auto serialize(NetlistGraph const &graph) -> std::string;

--- a/source/NetlistBuilder.cpp
+++ b/source/NetlistBuilder.cpp
@@ -494,6 +494,9 @@ void NetlistBuilder::handle(ast::InstanceSymbol const &symbol) {
   if (blackBox) {
     DEBUG_PRINT("Black-boxing instance {} ({})\n", symbol.name,
                 symbol.getDefinition().name);
+    // Record the resolved instance path so coverage queries work
+    // without the AST or the original patterns.
+    graph.addBlackBoxPath(symbol.getHierarchicalPath());
     // Materialize port nodes without descending into the body, so the
     // parent's port wiring has somewhere to terminate but no internal
     // logic contributes nodes or edges.

--- a/source/NetlistGraph.cpp
+++ b/source/NetlistGraph.cpp
@@ -240,3 +240,32 @@ auto NetlistGraph::findNodesRegex(std::string_view pattern) const
   }
   return result;
 }
+
+auto NetlistGraph::getBlackBoxCoverage(NetlistNode const &node) const
+    -> BlackBoxCoverage {
+  auto path = node.getHierarchicalPath();
+  if (!path) {
+    return BlackBoxCoverage::Outside;
+  }
+  auto result = BlackBoxCoverage::Outside;
+  for (auto const &bbPath : blackBoxPaths) {
+    if (!path->starts_with(bbPath)) {
+      continue;
+    }
+    if (path->size() == bbPath.size()) {
+      return BlackBoxCoverage::Contained;
+    }
+    // The prefix must end on a path segment boundary.
+    if ((*path)[bbPath.size()] != '.') {
+      continue;
+    }
+    auto remainder = path->substr(bbPath.size() + 1);
+    if (node.kind == NodeKind::Port &&
+        remainder.find('.') == std::string_view::npos) {
+      result = BlackBoxCoverage::Boundary;
+    } else {
+      return BlackBoxCoverage::Contained;
+    }
+  }
+  return result;
+}

--- a/source/NetlistSerializer.cpp
+++ b/source/NetlistSerializer.cpp
@@ -165,6 +165,13 @@ auto NetlistSerializer::serialize(NetlistGraph const &graph) -> std::string {
   }
   root["fileTable"] = fileTableJson;
 
+  // Serialize black-box instance paths.
+  json blackBoxesJson = json::array();
+  for (auto const &path : graph.getBlackBoxPaths()) {
+    blackBoxesJson.push_back(path);
+  }
+  root["blackBoxes"] = blackBoxesJson;
+
   // Serialize nodes.
   json nodesJson = json::array();
   for (auto const &nodePtr : graph) {
@@ -268,6 +275,13 @@ void NetlistSerializer::deserialize(std::string_view jsonStr,
   // Deserialize file table.
   for (auto const &entry : root.at("fileTable")) {
     graph.fileTable.addFile(entry.get<std::string>());
+  }
+
+  // Deserialize black-box instance paths (absent means none).
+  if (root.contains("blackBoxes")) {
+    for (auto const &entry : root.at("blackBoxes")) {
+      graph.addBlackBoxPath(entry.get<std::string>());
+    }
   }
 
   // Deserialize nodes.

--- a/tests/driver/driver_tests.py
+++ b/tests/driver/driver_tests.py
@@ -156,7 +156,7 @@ comb-loop.sv:10:10: note: assignment
             self.assertEqual(result.returncode, 0)
             with open(outfile) as f:
                 data = json.load(f)
-            self.assertEqual(data["version"], 2)
+            self.assertEqual(data["version"], 3)
             self.assertIn("fileTable", data)
             self.assertIn("nodes", data)
             self.assertIn("edges", data)

--- a/tests/unit/BlackBoxTests.cpp
+++ b/tests/unit/BlackBoxTests.cpp
@@ -319,6 +319,170 @@ endmodule
   CHECK_FALSE(test.pathExists("top.a", "top.c"));
 }
 
+TEST_CASE("Coverage: boundary ports and outside nodes", "[BlackBox]") {
+  auto const tree = R"(
+module foo(input logic x, input logic y, output logic z);
+  assign z = x | y;
+endmodule
+
+module top(input logic a, input logic b, output logic c);
+  foo u_mux(.x(a), .y(b), .z(c));
+endmodule
+)";
+  BuilderOptions opts;
+  opts.blackBoxes = {"foo"};
+  NetlistTest test(tree, opts);
+
+  // The resolved instance path is recorded on the graph.
+  auto paths = test.graph.getBlackBoxPaths();
+  REQUIRE(paths.size() == 1);
+  CHECK(paths[0] == "top.u_mux");
+
+  // Ports of the black-boxed instance are on the boundary.
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_mux.x")) ==
+        BlackBoxCoverage::Boundary);
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_mux.y")) ==
+        BlackBoxCoverage::Boundary);
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_mux.z")) ==
+        BlackBoxCoverage::Boundary);
+
+  // Nodes in the parent scope are outside.
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.a")) ==
+        BlackBoxCoverage::Outside);
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.c")) ==
+        BlackBoxCoverage::Outside);
+}
+
+TEST_CASE("Coverage: definition-name pattern records one path per instance",
+          "[BlackBox]") {
+  auto const tree = R"(
+module passthrough(input logic i, output logic o);
+  assign o = i;
+endmodule
+
+module top(input logic a, output logic c);
+  logic mid;
+  passthrough u_a(.i(a),   .o(mid));
+  passthrough u_b(.i(mid), .o(c));
+endmodule
+)";
+  BuilderOptions opts;
+  opts.blackBoxes = {"passthrough"};
+  NetlistTest test(tree, opts);
+
+  auto paths = test.graph.getBlackBoxPaths();
+  REQUIRE(paths.size() == 2);
+  CHECK(std::ranges::count(paths, "top.u_a") == 1);
+  CHECK(std::ranges::count(paths, "top.u_b") == 1);
+
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_a.i")) ==
+        BlackBoxCoverage::Boundary);
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_b.o")) ==
+        BlackBoxCoverage::Boundary);
+}
+
+TEST_CASE("Coverage: prefix matching is segment-aware", "[BlackBox]") {
+  auto const tree = R"(
+module passthrough(input logic i, output logic o);
+  assign o = i;
+endmodule
+
+module top(input logic a, output logic c);
+  logic mid;
+  passthrough u_a (.i(a),   .o(mid));
+  passthrough u_ab(.i(mid), .o(c));
+endmodule
+)";
+  BuilderOptions opts;
+  opts.blackBoxes = {"top.u_a"};
+  NetlistTest test(tree, opts);
+
+  // 'top.u_a' must not cover 'top.u_ab.*'.
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_a.i")) ==
+        BlackBoxCoverage::Boundary);
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_ab.i")) ==
+        BlackBoxCoverage::Outside);
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.u_ab.o")) ==
+        BlackBoxCoverage::Outside);
+}
+
+TEST_CASE("Coverage: nodes without hierarchical paths are outside",
+          "[BlackBox]") {
+  auto const tree = R"(
+module foo(input logic x, output logic z);
+  assign z = x;
+endmodule
+
+module top(input logic a, output logic c);
+  logic w;
+  assign w = a;
+  foo u_foo(.x(w), .z(c));
+endmodule
+)";
+  BuilderOptions opts;
+  opts.blackBoxes = {"foo"};
+  NetlistTest test(tree, opts);
+
+  for (auto const &node : test.graph.filterNodes(NodeKind::Assignment)) {
+    CHECK(test.graph.getBlackBoxCoverage(*node) == BlackBoxCoverage::Outside);
+  }
+}
+
+TEST_CASE("Coverage: contained nodes under a manually added path",
+          "[BlackBox]") {
+  auto const tree = R"(
+module leaf(input logic i, output logic o);
+  assign o = i;
+endmodule
+
+module mid(input logic clk, input logic i, output logic o);
+  logic q;
+  always_ff @(posedge clk) q <= i;
+  leaf u_leaf(.i(q), .o(o));
+endmodule
+
+module top(input logic clk, input logic a, output logic c);
+  mid u_mid(.clk(clk), .i(a), .o(c));
+endmodule
+)";
+  // Build the full graph (no build-time black-boxing), then register the
+  // box afterwards, as a deserialized or query-time consumer would.
+  NetlistTest test(tree);
+  test.graph.addBlackBoxPath("top.u_mid");
+
+  auto coverage = [&](std::string const &name) {
+    auto *node = test.graph.lookup(name);
+    REQUIRE(node != nullptr);
+    return test.graph.getBlackBoxCoverage(*node);
+  };
+
+  // Ports of the box are on the boundary.
+  CHECK(coverage("top.u_mid.i") == BlackBoxCoverage::Boundary);
+  CHECK(coverage("top.u_mid.o") == BlackBoxCoverage::Boundary);
+
+  // A non-port node directly under the box is contained, as is anything
+  // deeper, including ports of nested instances.
+  CHECK(coverage("top.u_mid.q") == BlackBoxCoverage::Contained);
+  CHECK(coverage("top.u_mid.u_leaf.i") == BlackBoxCoverage::Contained);
+
+  // Parent-scope nodes are outside.
+  CHECK(coverage("top.a") == BlackBoxCoverage::Outside);
+}
+
+TEST_CASE("Coverage: no black boxes means everything is outside",
+          "[BlackBox]") {
+  auto const tree = R"(
+module top(input logic a, output logic c);
+  assign c = a;
+endmodule
+)";
+  NetlistTest test(tree);
+
+  CHECK(test.graph.getBlackBoxPaths().empty());
+  CHECK(test.graph.getBlackBoxCoverage(*test.graph.lookup("top.a")) ==
+        BlackBoxCoverage::Outside);
+}
+
 TEST_CASE("Glob '...' is equivalent to '**' across path boundaries",
           "[BlackBox]") {
   auto const tree = R"(

--- a/tests/unit/SerializerTests.cpp
+++ b/tests/unit/SerializerTests.cpp
@@ -390,6 +390,38 @@ endmodule
   CHECK(foundInOut);
 }
 
+TEST_CASE("Round-trip preserves black-box paths and coverage", "[Serializer]") {
+  auto const &tree = R"(
+module foo(input logic x, output logic z);
+  assign z = x;
+endmodule
+
+module top(input logic a, output logic c);
+  foo u_foo(.x(a), .z(c));
+endmodule
+)";
+  BuilderOptions opts;
+  opts.blackBoxes = {"foo"};
+  NetlistTest test(tree, opts);
+  auto loaded = roundTrip(test);
+
+  auto paths = loaded->getBlackBoxPaths();
+  REQUIRE(paths.size() == 1);
+  CHECK(paths[0] == "top.u_foo");
+  CHECK(loaded->getBlackBoxCoverage(*loaded->lookup("top.u_foo.x")) ==
+        BlackBoxCoverage::Boundary);
+  CHECK(loaded->getBlackBoxCoverage(*loaded->lookup("top.a")) ==
+        BlackBoxCoverage::Outside);
+}
+
+TEST_CASE("Absent blackBoxes field deserializes to no black boxes",
+          "[Serializer]") {
+  auto json = R"({"version": 3, "fileTable": [], "nodes": [], "edges": []})";
+  NetlistGraph graph;
+  NetlistSerializer::deserialize(json, graph);
+  CHECK(graph.getBlackBoxPaths().empty());
+}
+
 TEST_CASE("Malformed JSON throws error", "[Serializer]") {
   NetlistGraph graph;
   CHECK_THROWS(NetlistSerializer::deserialize("not valid json", graph));


### PR DESCRIPTION
Record the resolved hierarchical path of each black-boxed instance on the graph and add a query to classify any node against those boxes.

Black boxes are specified by glob patterns over module definition names or instance paths, so the same pattern can match many instances. When an instance is black-boxed during the build, its concrete hierarchical path is now recorded via NetlistGraph::addBlackBoxPath. This resolves the pattern into concrete instance paths at the only point where both are known, so coverage queries need neither the AST nor the original patterns.

NetlistGraph::getBlackBoxCoverage classifies a node as Outside, Boundary, or Contained by segment-aware prefix matching on its hierarchical path: a Port directly below a black-boxed instance is on the boundary, any other node at or below one is contained, and everything else (including nodes without a path) is outside. Containment takes precedence over the boundary when boxes nest.

The paths are serialised in the JSON format (new blackBoxes field), bumping the format version to 3, so coverage works on deserialised graphs too.