### PR TITLE
Add --sensitivity and --constant-drivers CLI queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Library changes:
 * Bump the netlist JSON format to version 3: black-box instance paths are
   serialised in a new `blackBoxes` field.
 
+Driver features:
+* Add `--sensitivity <name>`, reporting the clocks and resets gating a named
+  node (a register's own clocking edges, or the union over registers in a
+  combinational node's fan-out).
+* Add `--constant-drivers <name>`, reporting the constant values driving a
+  named node when it is tied off to literals.
+
 ## [v0.10.0]
 
 Library features:

--- a/docs/user-guide.dox
+++ b/docs/user-guide.dox
@@ -101,6 +101,18 @@ node (all nodes reachable via combinational edges, stopping at registers).
 @c --fan-in @c \<name\> — report the combinational fan-in cone to a named
 node.
 
+@c --sensitivity @c \<name\> — report the clocks and resets gating a named
+node. For a register the node's own clocking edges are listed; for a
+combinational node the union of the clocking edges over every register in
+its combinational fan-out. Each entry shows the source signal, its edge
+kind, and source location.
+
+@c --constant-drivers @c \<name\> — report the constant values driving a
+named node when its combinational fan-in bottoms out only at literals
+(i.e. the node is tied off). Prints nothing if any register or external
+input reaches the node. Each entry shows the constant value and source
+location.
+
 @c --find @c \<pattern\> — find named nodes matching a glob pattern.
 See @ref glob-syntax for the full pattern syntax.
 

--- a/tests/driver/driver_tests.py
+++ b/tests/driver/driver_tests.py
@@ -430,6 +430,88 @@ comb-loop.sv:10:10: note: assignment
         )
         self.assertNotEqual(result.returncode, 0)
 
+    def test_sensitivity(self):
+        with tempfile.NamedTemporaryFile(suffix=".sv", delete=False, mode="w") as f:
+            f.write(
+                "module m(input logic clk, input logic rst_n,\n"
+                "         input logic d, output logic q);\n"
+                "  always_ff @(posedge clk or negedge rst_n)\n"
+                "    if (!rst_n) q <= 1'b0;\n"
+                "    else q <= d;\n"
+                "endmodule\n"
+            )
+            svfile = f.name
+        try:
+            result = subprocess.run(
+                [self.executable, svfile, "--sensitivity", "m.q"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("m.clk", result.stdout)
+            self.assertIn("PosEdge", result.stdout)
+            self.assertIn("m.rst_n", result.stdout)
+            self.assertIn("NegEdge", result.stdout)
+        finally:
+            os.unlink(svfile)
+
+    def test_sensitivity_nonexistent(self):
+        result = subprocess.run(
+            [
+                self.executable,
+                "rca.sv",
+                "--sensitivity",
+                "rca.nonexistent",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_constant_drivers(self):
+        with tempfile.NamedTemporaryFile(suffix=".sv", delete=False, mode="w") as f:
+            f.write(
+                "module m(input logic a, output logic [3:0] y,\n"
+                "         output logic w);\n"
+                "  assign y = 4'hA;\n"
+                "  assign w = a;\n"
+                "endmodule\n"
+            )
+            svfile = f.name
+        try:
+            # A tied-off output reports its constant value.
+            result = subprocess.run(
+                [self.executable, svfile, "--constant-drivers", "m.y"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("4'b1010", result.stdout)
+
+            # An output driven by an input is not constant-driven.
+            result = subprocess.run(
+                [self.executable, svfile, "--constant-drivers", "m.w"],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertNotIn("'b", result.stdout)
+        finally:
+            os.unlink(svfile)
+
+    def test_constant_drivers_nonexistent(self):
+        result = subprocess.run(
+            [
+                self.executable,
+                "rca.sv",
+                "--constant-drivers",
+                "rca.nonexistent",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -22,6 +22,7 @@
 
 #include "fmt/color.h"
 #include "fmt/format.h"
+#include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <string>
@@ -294,6 +295,23 @@ auto main(int argc, char **argv) -> int {
   driver.cmdLine.add("--fan-in", fanInName,
                      "Report the combinational fan-in cone to a named node",
                      "<name>");
+
+  std::optional<std::string> sensitivityName;
+  driver.cmdLine.add(
+      "--sensitivity", sensitivityName,
+      "Report the clocks/resets gating a named node. For a register the "
+      "node's own clocking edges are listed; otherwise the union over every "
+      "register in its combinational fan-out.",
+      "<name>");
+
+  std::optional<std::string> constantDriversName;
+  driver.cmdLine.add(
+      "--constant-drivers", constantDriversName,
+      "Report the constant values driving a named node when its "
+      "combinational fan-in bottoms out only at literals (i.e. the node is "
+      "tied off). Prints nothing driving it if any register or external "
+      "input reaches the node.",
+      "<name>");
 
   std::optional<std::string> findPattern;
   driver.cmdLine.add(
@@ -659,6 +677,66 @@ auto main(int argc, char **argv) -> int {
                                          loc ? loc->toString(graph.fileTable)
                                              : std::string()});
         }
+      }
+      FormatBuffer buffer;
+      Utilities::formatTable(buffer, header, table);
+      OS::print(buffer.str());
+      printStats();
+      return 0;
+    }
+
+    // Report the clocks/resets gating a named node. A single hierarchical
+    // name can resolve to several nodes (e.g. a register's State node and
+    // its same-named output Port), so aggregate sensitivity across all of
+    // them and deduplicate.
+    if (sensitivityName.has_value()) {
+      auto nodes = graph.findNodes(*sensitivityName);
+      if (nodes.empty()) {
+        SLANG_THROW(std::runtime_error(
+            fmt::format("could not find node: {}", *sensitivityName)));
+      }
+      std::vector<NetlistGraph::SensitivitySource> sensitivity;
+      for (auto *node : nodes) {
+        for (auto const &src : graph.getSensitivity(*node)) {
+          if (std::find(sensitivity.begin(), sensitivity.end(), src) ==
+              sensitivity.end()) {
+            sensitivity.push_back(src);
+          }
+        }
+      }
+      auto header = Utilities::Row{"Name", "Edge", "Location"};
+      auto table = Utilities::Table{};
+      for (auto const &src : sensitivity) {
+        auto path = src.source->getHierarchicalPath();
+        auto loc = src.source->getLocation();
+        table.push_back(Utilities::Row{std::string(path.value_or("(unnamed)")),
+                                       std::string(ast::toString(src.edgeKind)),
+                                       loc ? loc->toString(graph.fileTable)
+                                           : std::string()});
+      }
+      FormatBuffer buffer;
+      Utilities::formatTable(buffer, header, table);
+      OS::print(buffer.str());
+      printStats();
+      return 0;
+    }
+
+    // Report the constant values driving a named node.
+    if (constantDriversName.has_value()) {
+      auto *node = graph.lookup(*constantDriversName);
+      if (node == nullptr) {
+        SLANG_THROW(std::runtime_error(
+            fmt::format("could not find node: {}", *constantDriversName)));
+      }
+      auto constants = graph.getConstantDrivers(*node);
+      auto header = Utilities::Row{"Value", "Location"};
+      auto table = Utilities::Table{};
+      for (auto const *n : constants) {
+        auto const &constant = n->as<Constant>();
+        auto loc = constant.getLocation();
+        table.push_back(Utilities::Row{constant.value.toString(),
+                                       loc ? loc->toString(graph.fileTable)
+                                           : std::string()});
       }
       FormatBuffer buffer;
       Utilities::formatTable(buffer, header, table);


### PR DESCRIPTION
Wire the existing NetlistGraph::getSensitivity and getConstantDrivers queries into slang-netlist. --sensitivity reports the clocks/resets gating a node; --constant-drivers reports the literals a tied-off node is driven by. --sensitivity aggregates over all nodes sharing a name so a register's State node is found even when its same-named output Port shadows it in lookup.