### PR TITLE
Add scoped DOT rendering to --netlist-dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Driver features:
   commands (`--report-registers`, `--find`, `--find-regex`, `--fan-out`,
   `--fan-in`, `--sensitivity`, `--constant-drivers`); `json` emits an array of
   objects keyed by the column headers.
+* `--netlist-dot` can now be scoped: combined with `--fan-out`, `--fan-in`, or
+  `--from`/`--to` it renders only that cone or path (the induced subgraph)
+  instead of the whole netlist.
 
 ## [v0.10.0]
 

--- a/docs/user-guide.dox
+++ b/docs/user-guide.dox
@@ -161,6 +161,15 @@ bit range. The DOT output can be rendered with Graphviz tools such as
 slang-netlist design.sv --netlist-dot - | dot -Tsvg -o netlist.svg
 @endcode
 
+By default the whole graph is rendered. Combine @c --netlist-dot with a
+@c --fan-out, @c --fan-in, or @c --from/@c --to selector to render only the
+relevant cone or path — the induced subgraph over those nodes — instead of
+the entire design:
+
+@code{.ansi}
+slang-netlist design.sv --netlist-dot - --fan-out top.sub.sig | dot -Tsvg -o cone.svg
+@endcode
+
 @c --save-netlist @c \<file\> — serialize the netlist graph to a JSON file
 for later reloading.
 

--- a/include/netlist/NetlistDot.hpp
+++ b/include/netlist/NetlistDot.hpp
@@ -5,63 +5,97 @@
 
 #include "slang/text/FormatBuffer.h"
 
+#include <unordered_set>
+
 namespace slang::netlist {
 
 /// A utility class for rendering a netlist graph in DOT format.
 struct NetlistDot {
 
+  /// Render the whole netlist graph.
   static auto render(NetlistGraph const &netlist, FormatBuffer &buffer) {
+    renderImpl(netlist, buffer, nullptr);
+  }
+
+  /// Render only the induced subgraph over @p nodes: nodes not in the set are
+  /// omitted, and an edge is kept only when both of its endpoints are in the
+  /// set. Useful for rendering a fan-in/fan-out cone or a path in isolation.
+  static auto render(NetlistGraph const &netlist, FormatBuffer &buffer,
+                     std::unordered_set<NetlistNode const *> const &nodes) {
+    renderImpl(netlist, buffer, &nodes);
+  }
+
+private:
+  static void writeNode(FormatBuffer &buffer, NetlistNode const &node) {
+    switch (node.kind) {
+    case NodeKind::Port: {
+      auto const &portNode = node.as<Port>();
+      buffer.format("  N{} [label=\"{} port {}\"]\n", node.ID,
+                    toString(portNode.direction), portNode.name);
+      break;
+    }
+    case NodeKind::Variable: {
+      auto const &varNode = node.as<Variable>();
+      buffer.format("  N{} [label=\"Variable {}\"]\n", node.ID, varNode.name);
+      break;
+    }
+    case NodeKind::Assignment: {
+      buffer.format("  N{} [label=\"Assignment\"]\n", node.ID);
+      break;
+    }
+    case NodeKind::Case: {
+      buffer.format("  N{} [label=\"Case\"]\n", node.ID);
+      break;
+    }
+    case NodeKind::Conditional: {
+      buffer.format("  N{} [label=\"Conditional\"]\n", node.ID);
+      break;
+    }
+    case NodeKind::Merge: {
+      buffer.format("  N{} [label=\"Merge\"]\n", node.ID);
+      break;
+    }
+    case NodeKind::State: {
+      auto const &state = node.as<State>();
+      buffer.format("  N{} [label=\"{} {}\"]\n", node.ID, state.name,
+                    toString(state.bounds));
+      break;
+    }
+    case NodeKind::Constant: {
+      auto const &constNode = node.as<Constant>();
+      buffer.format("  N{} [label=\"Const {}\"]\n", node.ID,
+                    constNode.value.toString());
+      break;
+    }
+    default:
+      SLANG_UNREACHABLE;
+    }
+  }
+
+  static void
+  renderImpl(NetlistGraph const &netlist, FormatBuffer &buffer,
+             std::unordered_set<NetlistNode const *> const *filter) {
+    auto included = [&](NetlistNode const &node) {
+      return filter == nullptr || filter->count(&node) != 0;
+    };
+
     buffer.append("digraph {\n");
     buffer.append("  node [shape=record];\n");
-    for (auto &node : netlist) {
-      switch (node->kind) {
-      case NodeKind::Port: {
-        auto &portNode = node->as<Port>();
-        buffer.format("  N{} [label=\"{} port {}\"]\n", node->ID,
-                      toString(portNode.direction), portNode.name);
-        break;
+    for (auto const &node : netlist) {
+      if (!included(*node)) {
+        continue;
       }
-      case NodeKind::Variable: {
-        auto &varNode = node->as<Variable>();
-        buffer.format("  N{} [label=\"Variable {}\"]\n", node->ID,
-                      varNode.name);
-        break;
-      }
-      case NodeKind::Assignment: {
-        buffer.format("  N{} [label=\"Assignment\"]\n", node->ID);
-        break;
-      }
-      case NodeKind::Case: {
-        buffer.format("  N{} [label=\"Case\"]\n", node->ID);
-        break;
-      }
-      case NodeKind::Conditional: {
-        buffer.format("  N{} [label=\"Conditional\"]\n", node->ID);
-        break;
-      }
-      case NodeKind::Merge: {
-        buffer.format("  N{} [label=\"Merge\"]\n", node->ID);
-        break;
-      }
-      case NodeKind::State: {
-        auto &state = node->as<State>();
-        buffer.format("  N{} [label=\"{} {}\"]\n", node->ID, state.name,
-                      toString(state.bounds));
-        break;
-      }
-      case NodeKind::Constant: {
-        auto &constNode = node->as<Constant>();
-        buffer.format("  N{} [label=\"Const {}\"]\n", node->ID,
-                      constNode.value.toString());
-        break;
-      }
-      default:
-        SLANG_UNREACHABLE;
-      }
+      writeNode(buffer, *node);
     }
     for (auto const &node : netlist) {
+      if (!included(*node)) {
+        continue;
+      }
       for (auto const &edge : node->getOutEdges()) {
         if (edge->disabled) {
+          continue;
+        }
+        if (!included(edge->getTargetNode())) {
           continue;
         }
         if (edge->symbol != nullptr && !edge->symbol->empty()) {

--- a/tests/driver/driver_tests.py
+++ b/tests/driver/driver_tests.py
@@ -38,6 +38,13 @@ module m(input logic a, output logic [3:0] y,
 endmodule
 """
 
+DOT_SCOPE_SV = """\
+module m(input logic a, input logic b, output logic x, output logic y);
+  assign x = a;
+  assign y = b;
+endmodule
+"""
+
 SENS_SIMPLE_SV = """\
 module m(input logic clk, input logic d, output logic q);
   always_ff @(posedge clk) q <= d;
@@ -317,6 +324,48 @@ comb-loop.sv:10:10: note: assignment
         )
         self.assertNotEqual(r.returncode, 0)
         self.assertIn("unknown --format value", r.stderr)
+
+    def test_netlist_dot_full(self):
+        # Without a scope selector the whole graph is rendered.
+        r = self.run_tool("--netlist-dot", "-", source=DOT_SCOPE_SV)
+        self.assertIn("digraph", r.stdout)
+        for name in ("port a", "port b", "port x", "port y"):
+            self.assertIn(name, r.stdout)
+
+    def test_netlist_dot_scoped_fan_out(self):
+        # Scoping to a fan-out cone excludes the independent b -> y cone.
+        r = self.run_tool("--netlist-dot", "-", "--fan-out", "m.a", source=DOT_SCOPE_SV)
+        self.assertIn("port a", r.stdout)
+        self.assertIn("port x", r.stdout)
+        self.assertNotIn("port b", r.stdout)
+        self.assertNotIn("port y", r.stdout)
+
+    def test_netlist_dot_scoped_fan_in(self):
+        r = self.run_tool("--netlist-dot", "-", "--fan-in", "m.x", source=DOT_SCOPE_SV)
+        self.assertIn("port a", r.stdout)
+        self.assertIn("port x", r.stdout)
+        self.assertNotIn("port y", r.stdout)
+
+    def test_netlist_dot_scoped_path(self):
+        r = self.run_tool(
+            "--netlist-dot", "-", "--from", "m.a", "--to", "m.x", source=DOT_SCOPE_SV
+        )
+        self.assertIn("port a", r.stdout)
+        self.assertIn("port x", r.stdout)
+        self.assertNotIn("port y", r.stdout)
+
+    def test_netlist_dot_scoped_no_path(self):
+        r = self.run_tool(
+            "--netlist-dot",
+            "-",
+            "--from",
+            "m.a",
+            "--to",
+            "m.y",
+            source=DOT_SCOPE_SV,
+            check=False,
+        )
+        self.assertNotEqual(r.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/NetlistDotTests.cpp
+++ b/tests/unit/NetlistDotTests.cpp
@@ -178,3 +178,31 @@ endmodule
   CHECK(dot.find("Conditional") == std::string::npos);
   CHECK(dot.find("Case") == std::string::npos);
 }
+
+TEST_CASE("Scoped DOT renders only the selected subgraph", "[Dot]") {
+  auto const &tree = R"(
+module m(input logic a, input logic b, output logic x, output logic y);
+  assign x = a;
+  assign y = b;
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto *start = test.graph.lookup("m.a");
+  REQUIRE(start != nullptr);
+
+  std::unordered_set<NetlistNode const *> scope;
+  scope.insert(start);
+  for (auto *node : test.graph.getCombFanOut(*start)) {
+    scope.insert(node);
+  }
+
+  FormatBuffer buffer;
+  NetlistDot::render(test.graph, buffer, scope);
+  auto dot = std::string(buffer.str());
+
+  CHECK(dot.find("port a") != std::string::npos);
+  CHECK(dot.find("port x") != std::string::npos);
+  // The independent b -> y cone must be excluded.
+  CHECK(dot.find("port b") == std::string::npos);
+  CHECK(dot.find("port y") == std::string::npos);
+}

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -275,7 +276,8 @@ auto main(int argc, char **argv) -> int {
   std::optional<std::string> netlistDotFile;
   driver.cmdLine.add("--netlist-dot", netlistDotFile,
                      "Dump the netlist in DOT format to the specified file, "
-                     "or '-' for stdout",
+                     "or '-' for stdout. Combine with --fan-out, --fan-in or "
+                     "--from/--to to render only that cone or path.",
                      "<file>", CommandLineFlags::FilePath);
 
   std::optional<std::string> fromPointName;
@@ -669,10 +671,51 @@ auto main(int argc, char **argv) -> int {
       return 0;
     }
 
-    // Output a DOT file of the netlist.
+    // Output a DOT file of the netlist. When combined with a fan-out, fan-in
+    // or path selector, render only that induced subgraph instead of the
+    // whole netlist.
     if (netlistDotFile) {
+      auto requireNode = [&](std::string const &name) -> NetlistNode * {
+        auto *node = graph.lookup(name);
+        if (node == nullptr) {
+          SLANG_THROW(
+              std::runtime_error(fmt::format("could not find node: {}", name)));
+        }
+        return node;
+      };
+
       FormatBuffer buffer;
-      NetlistDot::render(graph, buffer);
+      if (fanOutName || fanInName || (fromPointName && toPointName)) {
+        std::unordered_set<NetlistNode const *> scope;
+        if (fanOutName) {
+          auto *node = requireNode(*fanOutName);
+          scope.insert(node);
+          for (auto *n : graph.getCombFanOut(*node)) {
+            scope.insert(n);
+          }
+        } else if (fanInName) {
+          auto *node = requireNode(*fanInName);
+          scope.insert(node);
+          for (auto *n : graph.getCombFanIn(*node)) {
+            scope.insert(n);
+          }
+        } else {
+          auto *fromPoint = requireNode(*fromPointName);
+          auto *toPoint = requireNode(*toPointName);
+          PathFinder pathFinder;
+          auto path = pathFinder.find(*fromPoint, *toPoint);
+          if (path.empty()) {
+            SLANG_THROW(std::runtime_error(fmt::format(
+                "no path between {} and {}", *fromPointName, *toPointName)));
+          }
+          for (auto const *n : path) {
+            scope.insert(n);
+          }
+        }
+        NetlistDot::render(graph, buffer, scope);
+      } else {
+        NetlistDot::render(graph, buffer);
+      }
       OS::writeFile(*netlistDotFile, buffer.str());
       printStats();
       return 0;


### PR DESCRIPTION
Combine `--netlist-dot` with a `--fan-out`, `--fan-in`, or `--from`/`--to` selector to render only that cone or path instead of the whole netlist. Without a selector the full graph is rendered as before.

Refactor `NetlistDot::render` into a shared implementation and add an overload taking a node set that renders the induced subgraph nodes not in the set are omitted and an edge is kept only when both endpoints are in the set. The whole-graph path delegates to the same code, so its output is unchanged. The CLI builds the node set from `getCombFanOut` / `getCombFanIn` (plus the queried node) or from `PathFinder`, and reports an error when the node is missing or no path exists.