### PR TITLE
Alias lone --from/--to to fan-out/fan-in cones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Driver features:
 * `--netlist-dot` can now be scoped: combined with `--fan-out`, `--fan-in`, or
   `--from`/`--to` it renders only that cone or path (the induced subgraph)
   instead of the whole netlist.
+* `--from` and `--to` may now be used on their own: a lone `--from` reports the
+  combinational fan-out cone (like `--fan-out`) and a lone `--to` the fan-in
+  cone (like `--fan-in`), for both tabular output and scoped `--netlist-dot`.
 
 ## [v0.10.0]
 

--- a/docs/user-guide.dox
+++ b/docs/user-guide.dox
@@ -95,6 +95,12 @@ When the design has been compiled with the slang AST available, source locations
 are available and the output includes annotated source lines; otherwise after
 loading a serialised netlist, a plain @c file:line:col format is used.
 
+Either endpoint may be given on its own. @c --from @c \<name\> alone reports the
+combinational fan-out cone from the node (equivalent to @c --fan-out), and
+@c --to @c \<name\> alone reports the combinational fan-in cone to it
+(equivalent to @c --fan-in). An explicit @c --fan-out / @c --fan-in takes
+precedence over the aliased endpoint.
+
 @c --fan-out @c \<name\> — report the combinational fan-out cone from a named
 node (all nodes reachable via combinational edges, stopping at registers).
 

--- a/tests/driver/driver_tests.py
+++ b/tests/driver/driver_tests.py
@@ -267,6 +267,34 @@ comb-loop.sv:10:10: note: assignment
     def test_fan_in_nonexistent(self):
         self.assert_fails("rca.sv", "--fan-in", "rca.nonexistent")
 
+    def _write_sv(self, source):
+        """Write source to a temp .sv file, returning its path; unlinked on
+        test teardown."""
+        sv = tempfile.NamedTemporaryFile(suffix=".sv", mode="w", delete=False)
+        sv.write(source)
+        sv.close()
+        self.addCleanup(os.unlink, sv.name)
+        return sv.name
+
+    def test_from_alone_aliases_fan_out(self):
+        # A lone --from reports the fan-out cone, exactly like --fan-out. Reuse
+        # one file so the location column matches; compare as line sets to stay
+        # robust to row ordering.
+        path = self._write_sv(FANOUT_SV)
+        from_out = self.run_tool(path, "--from", "m.a").stdout
+        fan_out = self.run_tool(path, "--fan-out", "m.a").stdout
+        self.assertEqual(set(from_out.splitlines()), set(fan_out.splitlines()))
+
+    def test_to_alone_aliases_fan_in(self):
+        # A lone --to reports the fan-in cone, exactly like --fan-in.
+        path = self._write_sv(FANIN_SV)
+        to_out = self.run_tool(path, "--to", "m.y").stdout
+        fan_in = self.run_tool(path, "--fan-in", "m.y").stdout
+        self.assertEqual(set(to_out.splitlines()), set(fan_in.splitlines()))
+
+    def test_from_alone_nonexistent(self):
+        self.assert_fails("rca.sv", "--from", "rca.nonexistent")
+
     def test_sensitivity(self):
         r = self.run_tool("--sensitivity", "m.q", source=SENS_SV)
         self.assertIn("m.clk", r.stdout)
@@ -395,6 +423,21 @@ comb-loop.sv:10:10: note: assignment
             check=False,
         )
         self.assertNotEqual(r.returncode, 0)
+
+    def test_netlist_dot_scoped_from_alone(self):
+        # A lone --from scopes the DOT output to the reachable fan-out cone.
+        r = self.run_tool("--netlist-dot", "-", "--from", "m.a", source=DOT_SCOPE_SV)
+        self.assertIn("port a", r.stdout)
+        self.assertIn("port x", r.stdout)
+        self.assertNotIn("port b", r.stdout)
+        self.assertNotIn("port y", r.stdout)
+
+    def test_netlist_dot_scoped_to_alone(self):
+        # A lone --to scopes the DOT output to the reachable fan-in cone.
+        r = self.run_tool("--netlist-dot", "-", "--to", "m.x", source=DOT_SCOPE_SV)
+        self.assertIn("port a", r.stdout)
+        self.assertIn("port x", r.stdout)
+        self.assertNotIn("port y", r.stdout)
 
 
 if __name__ == "__main__":

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -283,12 +283,17 @@ auto main(int argc, char **argv) -> int {
 
   std::optional<std::string> fromPointName;
   driver.cmdLine.add("--from", fromPointName,
-                     "Specify a start point from which to trace a path",
+                     "Specify a start point from which to trace a path. Used "
+                     "alone (without --to), reports the combinational fan-out "
+                     "cone from the node.",
                      "<name>");
 
   std::optional<std::string> toPointName;
   driver.cmdLine.add("--to", toPointName,
-                     "Specify a finish point to trace a path to", "<name>");
+                     "Specify a finish point to trace a path to. Used alone "
+                     "(without --from), reports the combinational fan-in cone "
+                     "to the node.",
+                     "<name>");
 
   std::optional<std::string> fanOutName;
   driver.cmdLine.add("--fan-out", fanOutName,
@@ -715,6 +720,18 @@ auto main(int argc, char **argv) -> int {
     }
 
     // --- Analysis commands that work on both built and loaded netlists ---
+
+    // A lone --from/--to endpoint means "the reachable cone", which is exactly
+    // the combinational fan-out/fan-in from that node. Alias it onto the
+    // corresponding cone selector so every downstream handler (tabular output
+    // and scoped --netlist-dot) treats them uniformly. When both endpoints are
+    // given, path-finding takes over instead; an explicit --fan-out/--fan-in
+    // always wins.
+    if (fromPointName && !toPointName && !fanOutName) {
+      fanOutName = fromPointName;
+    } else if (toPointName && !fromPointName && !fanInName) {
+      fanInName = toPointName;
+    }
 
     if (reportRegisters) {
       auto header = Utilities::Row{"Name", "Location"};


### PR DESCRIPTION
A single --from (without `--to`) now reports the combinational fan-out cone from the node, and a lone `--to` reports the fan-in cone — the same result as `--fan-out`/`--fan-in`. Both endpoints together still trace a path. The alias is a normalization step applied before command dispatch, so it also scopes `--netlist-dot`. An explicit `--fan-out`/`--fan-in` takes precedence.