### PR TITLE
Add --scope/--name filters to node-listing query commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ Driver features:
 * `--from` and `--to` may now be used on their own: a lone `--from` reports the
   combinational fan-out cone (like `--fan-out`) and a lone `--to` the fan-in
   cone (like `--fan-in`), for both tabular output and scoped `--netlist-dot`.
+* Add `--scope <path>` and `--name <pattern>` filters to the node-listing query
+  commands (`--report-registers`, `--find`, `--find-regex`, `--fan-out`,
+  `--fan-in`, `--sensitivity`). `--scope` restricts output to a hierarchical
+  subtree (segment-aware, so `top.cpu` excludes `top.cpu2`); `--name` restricts
+  to nodes whose path matches a glob. Both are repeatable and combine as
+  in-scope AND name-match.
 
 ## [v0.10.0]
 

--- a/docs/user-guide.dox
+++ b/docs/user-guide.dox
@@ -131,6 +131,22 @@ See @ref glob-syntax for the full pattern syntax.
 
 @c --find-regex @c \<pattern\> — find named nodes matching a regex pattern.
 
+@par Filtering by scope or name
+
+The node-listing query commands (@c --report-registers, @c --find,
+@c --find-regex, @c --fan-out, @c --fan-in, and @c --sensitivity) accept
+@c --scope @c \<path\> and @c --name @c \<pattern\> to constrain their output.
+@c --scope keeps only nodes within a hierarchical subtree: a node passes if its
+path is the scope or a descendant of it, so @c top.cpu matches @c top.cpu.alu.x
+but not @c top.cpu2. @c --name keeps only nodes whose hierarchical path matches
+a glob pattern (see @ref glob-syntax). Both options may be repeated; a node
+passes if it lies in one of the scopes @b and matches one of the names. Scopes
+are literal paths — use @c --name for glob matching across a subtree.
+
+@code{.ansi}
+slang-netlist design.sv --report-registers --scope top.cpu --name "**.q_reg"
+@endcode
+
 @par Output format
 
 The tabular query and report commands (@c --report-registers, @c --find,

--- a/include/common/Wildcard.hpp
+++ b/include/common/Wildcard.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 namespace slang::netlist {
 
 /// Glob-style pattern matching against hierarchical names whose path
@@ -150,6 +152,17 @@ inline auto wildcardMatch(const char *text, const char *pattern) -> bool {
     ++text;
   }
   return *text == '\0';
+}
+
+/// Return true if @p path is @p scope itself or a descendant of it, treating
+/// `.` as the hierarchy separator. So `top.cpu` contains `top.cpu` and
+/// `top.cpu.alu.x`, but not `top.cpu2`. Matching is literal; use
+/// wildcardMatch for glob patterns.
+inline auto pathInScope(std::string_view path, std::string_view scope) -> bool {
+  if (path.size() < scope.size() || path.substr(0, scope.size()) != scope) {
+    return false;
+  }
+  return path.size() == scope.size() || path[scope.size()] == '.';
 }
 
 } // namespace slang::netlist

--- a/tests/driver/driver_tests.py
+++ b/tests/driver/driver_tests.py
@@ -64,6 +64,21 @@ module m(input logic [3:0] a, input logic [3:0] b, output logic [3:0] y);
 endmodule
 """
 
+# Two instances of the same submodule (cpu and cpu2) so scope-boundary tests
+# can distinguish top.cpu from top.cpu2.
+FILTER_SV = """\
+module sub(input logic clk, input logic d, output logic q);
+  logic r;
+  always_ff @(posedge clk) r <= d;
+  assign q = r;
+endmodule
+module top(input logic clk, input logic d,
+           output logic q1, output logic q2);
+  sub cpu(.clk, .d, .q(q1));
+  sub cpu2(.clk, .d, .q(q2));
+endmodule
+"""
+
 
 class DriverTests(unittest.TestCase):
     executable = ...
@@ -294,6 +309,46 @@ comb-loop.sv:10:10: note: assignment
 
     def test_from_alone_nonexistent(self):
         self.assert_fails("rca.sv", "--from", "rca.nonexistent")
+
+    def test_scope_restricts_to_subtree(self):
+        # --scope keeps only nodes within the subtree, segment-aware so
+        # top.cpu excludes the sibling top.cpu2.
+        r = self.run_tool("--report-registers", "--scope", "top.cpu", source=FILTER_SV)
+        self.assertIn("top.cpu.r", r.stdout)
+        self.assertNotIn("top.cpu2.r", r.stdout)
+
+    def test_name_glob_filter(self):
+        r = self.run_tool("--report-registers", "--name", "**.cpu2.*", source=FILTER_SV)
+        self.assertIn("top.cpu2.r", r.stdout)
+        self.assertNotIn("top.cpu.r", r.stdout)
+
+    def test_scope_and_name_combine(self):
+        # Both filters apply: a node must be in-scope AND match the name.
+        r = self.run_tool(
+            "--report-registers",
+            "--scope",
+            "top.cpu2",
+            "--name",
+            "**.r",
+            source=FILTER_SV,
+        )
+        self.assertIn("top.cpu2.r", r.stdout)
+        self.assertNotIn("top.cpu.r", r.stdout)
+
+    def test_scope_no_match_is_empty(self):
+        # A scope matching nothing yields an empty table and exits zero.
+        r = self.run_tool(
+            "--report-registers", "--scope", "top.nonexistent", source=FILTER_SV
+        )
+        self.assertNotIn("top.cpu.r", r.stdout)
+        self.assertNotIn("top.cpu2.r", r.stdout)
+
+    def test_scope_filters_fan_out(self):
+        # The filters also apply to the cone commands.
+        r = self.run_tool(
+            "--fan-out", "top.cpu.r", "--scope", "top.cpu", source=FILTER_SV
+        )
+        self.assertNotIn("top.cpu2", r.stdout)
 
     def test_sensitivity(self):
         r = self.run_tool("--sensitivity", "m.q", source=SENS_SV)

--- a/tests/unit/WildcardTests.cpp
+++ b/tests/unit/WildcardTests.cpp
@@ -2,6 +2,7 @@
 
 #include "common/Wildcard.hpp"
 
+using slang::netlist::pathInScope;
 using slang::netlist::wildcardMatch;
 
 TEST_CASE("wildcardMatch exact literal", "[Wildcard]") {
@@ -106,4 +107,23 @@ TEST_CASE("wildcardMatch combinations", "[Wildcard]") {
   CHECK(wildcardMatch("top.u_a", "top.u_?"));
   CHECK_FALSE(wildcardMatch("top.u_ab", "top.u_?"));
   CHECK(wildcardMatch("top.u_ab", "top.u_?*"));
+}
+
+TEST_CASE("pathInScope subtree matching", "[Wildcard]") {
+  // A scope contains itself and any descendant.
+  CHECK(pathInScope("top.cpu", "top.cpu"));
+  CHECK(pathInScope("top.cpu.alu", "top.cpu"));
+  CHECK(pathInScope("top.cpu.alu.x", "top.cpu"));
+
+  // The boundary is segment-aware: a shared prefix within a segment does
+  // not count as being in scope.
+  CHECK_FALSE(pathInScope("top.cpu2", "top.cpu"));
+  CHECK_FALSE(pathInScope("top.cpualu", "top.cpu"));
+
+  // Ancestors and unrelated paths are not in scope.
+  CHECK_FALSE(pathInScope("top", "top.cpu"));
+  CHECK_FALSE(pathInScope("top.mem", "top.cpu"));
+
+  // A shorter path can never contain a longer scope.
+  CHECK_FALSE(pathInScope("top.c", "top.cpu"));
 }

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -1,6 +1,7 @@
 #include "slang/driver/Driver.h"
 
 #include "common/Utilities.hpp"
+#include "common/Wildcard.hpp"
 #include "netlist/BuilderOptions.hpp"
 #include "netlist/CombLoops.hpp"
 #include "netlist/Debug.hpp"
@@ -350,6 +351,25 @@ auto main(int argc, char **argv) -> int {
       "--constant-drivers, --drivers): 'table' (default) or 'json'",
       "<table|json>");
 
+  std::vector<std::string> scopeFilters;
+  driver.cmdLine.add(
+      "--scope", scopeFilters,
+      "Restrict the node-listing query commands (--report-registers, --find, "
+      "--find-regex, --fan-out, --fan-in, --sensitivity) to a hierarchical "
+      "subtree. A node passes if its path is the scope or a descendant of it "
+      "(so `top.cpu` matches `top.cpu.alu.x` but not `top.cpu2`). Literal "
+      "paths only; use --name for globs. May be repeated.",
+      "<path>");
+
+  std::vector<std::string> nameFilters;
+  driver.cmdLine.add(
+      "--name", nameFilters,
+      "Restrict the same node-listing query commands to nodes whose "
+      "hierarchical path matches a glob pattern (same syntax as --find: "
+      "`*`/`?` stay within a segment, `**`/`...` cross boundaries). May be "
+      "repeated.",
+      "<pattern>");
+
   std::optional<std::string> outputFile;
   driver.cmdLine.add("-o,--output", outputFile,
                      "Write tabular query output to the given file instead of "
@@ -443,6 +463,31 @@ auto main(int argc, char **argv) -> int {
       Utilities::formatTable(buffer, header, table);
       writeOutput(buffer.str());
     }
+  };
+
+  // Whether a node's hierarchical path passes the --scope/--name filters. A
+  // node must fall within some --scope subtree (if any given) and match some
+  // --name glob (if any given). With no filters set, everything passes.
+  auto passesFilters = [&](std::string_view path) -> bool {
+    if (!scopeFilters.empty()) {
+      auto inScope = std::any_of(
+          scopeFilters.begin(), scopeFilters.end(),
+          [&](auto const &scope) { return pathInScope(path, scope); });
+      if (!inScope) {
+        return false;
+      }
+    }
+    if (!nameFilters.empty()) {
+      std::string subject(path);
+      auto named = std::any_of(
+          nameFilters.begin(), nameFilters.end(), [&](auto const &p) {
+            return wildcardMatch(subject.c_str(), p.c_str());
+          });
+      if (!named) {
+        return false;
+      }
+    }
+    return true;
   };
 
   // Split a query of the form "path[hi:lo]" or "path[bit]" into a base path
@@ -739,6 +784,9 @@ auto main(int argc, char **argv) -> int {
 
       for (auto const &node : graph.filterNodes(NodeKind::State)) {
         auto const &stateNode = node->as<State>();
+        if (!passesFilters(stateNode.hierarchicalPath)) {
+          continue;
+        }
         auto loc = stateNode.location.toString(graph.fileTable);
         table.push_back(Utilities::Row{stateNode.hierarchicalPath, loc});
       }
@@ -824,6 +872,9 @@ auto main(int argc, char **argv) -> int {
       auto table = Utilities::Table{};
       for (auto const *node : nodes) {
         auto path = node->getHierarchicalPath();
+        if (!passesFilters(path.value_or(""))) {
+          continue;
+        }
         auto loc = node->getLocation();
         table.push_back(Utilities::Row{std::string(path.value_or("(unnamed)")),
                                        loc ? loc->toString(graph.fileTable)
@@ -846,7 +897,7 @@ auto main(int argc, char **argv) -> int {
       auto table = Utilities::Table{};
       for (auto const *n : fanOut) {
         auto path = n->getHierarchicalPath();
-        if (path.has_value()) {
+        if (path.has_value() && passesFilters(*path)) {
           auto loc = n->getLocation();
           table.push_back(Utilities::Row{std::string(*path),
                                          loc ? loc->toString(graph.fileTable)
@@ -870,7 +921,7 @@ auto main(int argc, char **argv) -> int {
       auto table = Utilities::Table{};
       for (auto const *n : fanIn) {
         auto path = n->getHierarchicalPath();
-        if (path.has_value()) {
+        if (path.has_value() && passesFilters(*path)) {
           auto loc = n->getLocation();
           table.push_back(Utilities::Row{std::string(*path),
                                          loc ? loc->toString(graph.fileTable)
@@ -905,6 +956,9 @@ auto main(int argc, char **argv) -> int {
       auto table = Utilities::Table{};
       for (auto const &src : sensitivity) {
         auto path = src.source->getHierarchicalPath();
+        if (!passesFilters(path.value_or(""))) {
+          continue;
+        }
         auto loc = src.source->getLocation();
         table.push_back(Utilities::Row{std::string(path.value_or("(unnamed)")),
                                        std::string(ast::toString(src.edgeKind)),


### PR DESCRIPTION
`--scope <path>` restricts output to a hierarchical subtree (segment-aware, so top.cpu excludes top.cpu2); `--name <pattern>` restricts to nodes whose path matches a glob. Both are repeatable and combine as in-scope AND name-match. They apply to `--report-registers`, `--find`, `--find-regex`, `--fan-out`, `--fan-in` and `--sensitivity`; `--constant-drivers` and `--drivers` are excluded since their rows are literal values, not node names.