### PR TITLE
Add support for get_drivers on Assignment/Conditional/... nodes

### DIFF
--- a/bindings/python/pyslang_netlist.cpp
+++ b/bindings/python/pyslang_netlist.cpp
@@ -143,6 +143,18 @@ PYBIND11_MODULE(pyslang_netlist, m) {
           "within a segment).")
       .def(
           "get_drivers",
+          [](const netlist::NetlistGraph &self, netlist::NetlistNode &node) {
+            py::list result;
+            for (auto *driver : self.getDrivers(node)) {
+              result.append(
+                  py::cast(driver, py::return_value_policy::reference));
+            }
+            return result;
+          },
+          py::arg("node"),
+          "Return driver nodes over full bit range.")
+      .def(
+          "get_drivers",
           [](const netlist::NetlistGraph &self, std::string_view name,
              int32_t lower, int32_t upper) {
             auto nodes =

--- a/docs/user-guide.dox
+++ b/docs/user-guide.dox
@@ -349,6 +349,10 @@ nodes = graph.find_nodes_regex(r"m\.[ab]")
 # Get drivers of a signal over a bit range.
 drivers = graph.get_drivers("m.b", 0, 0)
 
+# Get all drivers over the full bit range of any node, works with node types that
+# do not have an inherent bit range (e.g. Assignment nodes).
+drivers = graph.get_drivers(node)
+
 # Combinational fan-out / fan-in (stops at State nodes).
 fan_out = graph.get_comb_fan_out(node)
 fan_in  = graph.get_comb_fan_in(node)

--- a/include/netlist/NetlistGraph.hpp
+++ b/include/netlist/NetlistGraph.hpp
@@ -79,6 +79,13 @@ public:
                                 DriverBitRange bounds) const
       -> std::vector<NetlistNode *>;
 
+  /// Return the unique nodes with an incoming edge to @p node.
+  ///
+  /// This returns immediate drivers only. Use getCombFanIn for recursive
+  /// combinational fan-in.
+  [[nodiscard]] auto getDrivers(NetlistNode const &node) const
+      -> std::vector<NetlistNode *>;
+
   /// A driver node paired with the exact bit range of a queried symbol that
   /// it drives.
   struct BitDriver {

--- a/source/NetlistGraph.cpp
+++ b/source/NetlistGraph.cpp
@@ -82,6 +82,19 @@ auto NetlistGraph::getDrivers(std::string_view name,
   return result;
 }
 
+auto NetlistGraph::getDrivers(NetlistNode const &node) const
+    -> std::vector<NetlistNode *> {
+  std::unordered_set<NetlistNode *> seen;
+  std::vector<NetlistNode *> result;
+  for (auto const *edge : node.getInEdges()) {
+    auto *source = &edge->getSourceNode();
+    if (seen.insert(source).second) {
+      result.push_back(source);
+    }
+  }
+  return result;
+}
+
 auto NetlistGraph::getBitDrivers(std::string_view name,
                                  DriverBitRange bounds) const
     -> std::vector<BitDriver> {

--- a/tests/bindings/python/test_netlistgraph.py
+++ b/tests/bindings/python/test_netlistgraph.py
@@ -138,6 +138,37 @@ class TestNetlistGraph(unittest.TestCase):
         drivers = test.graph.get_drivers("m.b", 0, 0)
         self.assertGreater(len(drivers), 0)
 
+        assignment = next(
+            node
+            for node in test.graph
+            if node.kind == pyslang_netlist.NodeKind.Assignment
+        )
+        drivers = test.graph.get_drivers(assignment)
+        self.assertEqual(len(drivers), 1)
+        self.assertIsInstance(drivers[0], pyslang_netlist.Port)
+        self.assertEqual(drivers[0].path, "m.a")
+
+    def test_get_drivers_for_conditional(self):
+        code = """
+        module m(input logic en, input logic a, output logic y);
+            always_comb begin
+                if (en)
+                    y = a;
+                else
+                    y = 1'b0;
+            end
+        endmodule
+        """
+        test = NetlistGraphTest(code)
+        conditional = next(
+            node
+            for node in test.graph
+            if node.kind == pyslang_netlist.NodeKind.Conditional
+        )
+        drivers = test.graph.get_drivers(conditional)
+        paths = {node.path for node in drivers if hasattr(node, "path")}
+        self.assertIn("m.en", paths)
+
     def test_get_comb_fan_out(self):
         code = """
         module m(input logic a, output logic x, output logic y);

--- a/tests/unit/MiscTests.cpp
+++ b/tests/unit/MiscTests.cpp
@@ -317,6 +317,22 @@ endmodule
   CHECK(edgesFromPort == 2);
 }
 
+TEST_CASE("Get direct drivers for operation nodes", "[Netlist]") {
+  auto const &tree = R"(
+module m(input logic [3:0] a, output logic y);
+  assign y = a[0] ^ a[3];
+endmodule
+)";
+  const NetlistTest test(tree);
+  auto assignView = test.graph.filterNodes(NodeKind::Assignment);
+  REQUIRE_FALSE(assignView.empty());
+  auto &assignNode = *assignView.front();
+
+  auto drivers = test.graph.getDrivers(assignNode);
+  REQUIRE(drivers.size() == 1);
+  CHECK(drivers.front() == test.graph.lookup("m.a"));
+}
+
 TEST_CASE("Build profile is populated after graph construction", "[Netlist]") {
   auto const &tree = R"(
 module m(input logic a, output logic b);


### PR DESCRIPTION
The existing `get_drivers` exposed method requires knowing the bounds of the signal, which works for Port and State but not so well for Assignment and Conditional.